### PR TITLE
Claude: Fix first vercel deployment issue

### DIFF
--- a/app/api/webhooks/clerk/route.ts
+++ b/app/api/webhooks/clerk/route.ts
@@ -27,7 +27,6 @@ export async function POST(req: Request) {
 
   // Get the body
   const payload = await req.text();
-  const body = JSON.stringify({ body: payload });
 
   // Create a new Svix instance with your secret.
   const wh = new Webhook(WEBHOOK_SECRET);
@@ -49,7 +48,6 @@ export async function POST(req: Request) {
   }
 
   // Handle the webhook
-  const { id } = evt.data;
   const eventType = evt.type;
   
   if (eventType === 'user.created' || eventType === 'user.updated') {


### PR DESCRIPTION
Closes #4

  ## ✅ TypeScript Verified
  This PR was opened only after `npx tsc --noEmit` passed with zero errors.

  ## Changes
  Automatically generated by Claude Code in response to issue #4.