### PR TITLE
Claude: [UI] Sign-in/sign-up pages — dark theme, hide Clerk branding

### DIFF
--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -22,7 +22,10 @@ export default function SignInPage() {
             identityPreviewText: "text-muted-foreground",
             formResendCodeLink: "text-primary hover:text-primary/80",
             otpCodeFieldInput: "border-border",
-            alternativeMethodsBlockButton: "text-muted-foreground hover:text-foreground"
+            alternativeMethodsBlockButton: "text-muted-foreground hover:text-foreground",
+            footerAction: { display: 'none' },
+            footerPages: { display: 'none' },
+            logoBox: { display: 'none' }
           },
           layout: {
             logoPlacement: 'none'

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -22,7 +22,10 @@ export default function SignUpPage() {
             identityPreviewText: "text-muted-foreground",
             formResendCodeLink: "text-primary hover:text-primary/80",
             otpCodeFieldInput: "border-border",
-            alternativeMethodsBlockButton: "text-muted-foreground hover:text-foreground"
+            alternativeMethodsBlockButton: "text-muted-foreground hover:text-foreground",
+            footerAction: { display: 'none' },
+            footerPages: { display: 'none' },
+            logoBox: { display: 'none' }
           },
           layout: {
             logoPlacement: 'none'


### PR DESCRIPTION
Closes #8

  ## ✅ TypeScript Verified
  This PR was opened only after `npx tsc --noEmit` passed with zero errors.

  ## Changes
  Automatically generated by Claude Code in response to issue #8.