### PR TITLE
feat: add CoverLetterPDF component

### DIFF
--- a/lib/pdf/CoverLetterPDF.tsx
+++ b/lib/pdf/CoverLetterPDF.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+} from '@react-pdf/renderer';
+
+interface CoverLetterPDFProps {
+  coverLetterText: string;
+  candidateName: string;
+  company: string;
+  jobTitle: string;
+}
+
+const styles = StyleSheet.create({
+  page: {
+    flexDirection: 'column',
+    backgroundColor: '#ffffff',
+    padding: 72, // 1 inch = 72 points
+    fontFamily: 'Helvetica',
+    fontSize: 12,
+    lineHeight: 1.5,
+  },
+  date: {
+    textAlign: 'right',
+    marginBottom: 12,
+  },
+  addressBlock: {
+    marginBottom: 12,
+  },
+  greeting: {
+    marginBottom: 12,
+  },
+  bodyText: {
+    marginBottom: 12,
+    textAlign: 'justify',
+  },
+  closing: {
+    marginBottom: 48, // Space for signature
+  },
+  candidateName: {
+    // No additional styling needed
+  },
+});
+
+export default function CoverLetterPDF({ 
+  coverLetterText, 
+  candidateName, 
+  company, 
+  jobTitle 
+}: CoverLetterPDFProps) {
+  // Get today's date formatted
+  const today = new Date().toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+
+  // Split cover letter text into paragraphs
+  const paragraphs = coverLetterText
+    .split('\n\n')
+    .filter(paragraph => paragraph.trim().length > 0)
+    .map(paragraph => paragraph.trim());
+
+  return (
+    <Document>
+      <Page size="LETTER" style={styles.page}>
+        {/* Today's date (right aligned) */}
+        <Text style={styles.date}>{today}</Text>
+
+        {/* Blank line handled by marginBottom */}
+
+        {/* Company name and job title (address block) */}
+        <View style={styles.addressBlock}>
+          <Text>{company}</Text>
+          <Text>{jobTitle}</Text>
+        </View>
+
+        {/* Blank line handled by marginBottom */}
+
+        {/* Greeting */}
+        <Text style={styles.greeting}>Dear Hiring Manager,</Text>
+
+        {/* Blank line handled by marginBottom */}
+
+        {/* Cover letter body (3-4 paragraphs from generated text) */}
+        {paragraphs.map((paragraph, index) => (
+          <Text key={index} style={styles.bodyText}>
+            {paragraph}
+          </Text>
+        ))}
+
+        {/* Blank line handled by marginBottom */}
+
+        {/* Closing */}
+        <Text style={styles.closing}>Sincerely,</Text>
+
+        {/* Candidate name */}
+        <Text style={styles.candidateName}>{candidateName}</Text>
+      </Page>
+    </Document>
+  );
+}


### PR DESCRIPTION
Implements the cover letter PDF template as requested in issue #11.

## Changes
- Created `lib/pdf/CoverLetterPDF.tsx` with formal business letter layout
- Letter size (8.5" x 11") with 1" margins
- Helvetica font and proper spacing
- Auto-formats cover letter text into paragraphs

## Closes
- Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)