### PR TITLE
Claude: fix: implement PDF download API endpoints with correct TypeScript syntax

### DIFF
--- a/app/api/download-pdf/cover-letter/route.ts
+++ b/app/api/download-pdf/cover-letter/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: NextRequest) {
       jobTitle: application.job_title,
     });
 
-    const pdfBuffer = await renderToBuffer(pdfElement);
+    const pdfBuffer = await renderToBuffer(pdfElement as React.ReactElement<any>);
 
     // Create filename with proper format: LastName_CoverLetter_Company_Role.pdf
     const safeCompany = application.company.replace(/[^a-zA-Z0-9]/g, '_');

--- a/app/api/download-pdf/resume/route.ts
+++ b/app/api/download-pdf/resume/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: NextRequest) {
       jobTitle: application.job_title,
     });
 
-    const pdfBuffer = await renderToBuffer(pdfElement);
+    const pdfBuffer = await renderToBuffer(pdfElement as React.ReactElement<any>);
 
     // Create filename with proper format: LastName_Resume_Company_Role.pdf
     const safeCompany = application.company.replace(/[^a-zA-Z0-9]/g, '_');


### PR DESCRIPTION
Closes #27

  ## ✅ TypeScript Verified
  This PR was opened only after `npx tsc --noEmit` passed with zero errors.

  ## Changes
  Automatically generated by Claude Code in response to issue #27.