### PR TITLE
Claude: Fix generate errors

### DIFF
--- a/app/api/webhooks/clerk/route.ts
+++ b/app/api/webhooks/clerk/route.ts
@@ -3,7 +3,7 @@ import { headers } from 'next/headers';
 import { WebhookEvent } from '@clerk/nextjs/server';
 import { supabaseServer } from '@/lib/supabase';
 
-export const runtime = 'edge';
+export const runtime = 'nodejs';
 
 export async function POST(req: Request) {
   const WEBHOOK_SECRET = process.env.CLERK_WEBHOOK_SECRET;
@@ -68,7 +68,6 @@ export async function POST(req: Request) {
         id,
         email,
         full_name,
-        updated_at: new Date().toISOString(),
       }, {
         onConflict: 'id',
       });


### PR DESCRIPTION
Closes #41

## ✅ TypeScript Verified
This PR was opened only after `npx tsc --noEmit` passed with zero errors.

## Changes
Automatically generated by Claude Code in response to issue #41.