### PR TITLE
fix: implement actual PDF and DOCX parsing in extract-resume route

### DIFF
--- a/app/api/extract-resume/route.ts
+++ b/app/api/extract-resume/route.ts
@@ -3,10 +3,8 @@ export const runtime = 'nodejs';
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest } from 'next/server';
 
-// Note: These packages need to be installed
-// npm install pdf-parse mammoth @types/pdf-parse
-// const pdf = require('pdf-parse');
-// const mammoth = require('mammoth');
+const pdf = require('pdf-parse');
+const mammoth = require('mammoth');
 
 export async function POST(req: NextRequest) {
   console.log('[extract-resume] Request received');
@@ -49,21 +47,13 @@ export async function POST(req: NextRequest) {
       const buffer = Buffer.from(await file.arrayBuffer());
 
       if (file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')) {
-        // TODO: Install pdf-parse package
-        // const data = await pdf(buffer);
-        // extractedText = data.text;
-        
-        // Temporary placeholder - replace with actual PDF parsing
-        extractedText = 'PDF parsing requires pdf-parse package to be installed. Please run: npm install pdf-parse';
+        const data = await pdf(buffer);
+        extractedText = data.text;
         
       } else if (file.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' || 
                  file.name.toLowerCase().endsWith('.docx')) {
-        // TODO: Install mammoth package  
-        // const result = await mammoth.extractRawText({ buffer });
-        // extractedText = result.value;
-        
-        // Temporary placeholder - replace with actual DOCX parsing
-        extractedText = 'DOCX parsing requires mammoth package to be installed. Please run: npm install mammoth';
+        const result = await mammoth.extractRawText({ buffer });
+        extractedText = result.value;
       }
 
       if (!extractedText.trim()) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "clsx": "^2.1.1",
     "tailwind-merge": "^2.5.0",
     "@radix-ui/react-slot": "^1.1.0",
-    "svix": "^1.36.0"
+    "svix": "^1.36.0",
+    "pdf-parse": "^1.1.1",
+    "mammoth": "^1.6.0"
   },
   "devDependencies": {
     "typescript": "^5",
@@ -31,6 +33,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "eslint": "^8",
-    "eslint-config-next": "14.2.35"
+    "eslint-config-next": "14.2.35",
+    "@types/pdf-parse": "^1.1.1"
   }
 }


### PR DESCRIPTION
Fixes the extract-resume route to actually parse uploaded files instead of returning placeholder text.

## Changes
- Added pdf-parse and mammoth dependencies to package.json
- Uncommented real PDF and DOCX parsing code
- Removed all placeholder text and TODO comments
- Route now extracts actual text from uploaded files

Generated with [Claude Code](https://claude.ai/code)