### PR TITLE
feat: resume-only mode with optional cover letter toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,32 @@ Current valid columns:
 - Assume a column exists because it seems logical — check this
   file first
 
+## API Routes
+
+| Route | Runtime | Purpose |
+|-------|---------|---------|
+| `POST /api/analyze-fit` | Node | Haiku fit analysis — returns JSON FitAnalysis |
+| `POST /api/generate-documents` | Edge | SSE stream — resume (+ optional cover letter) generation |
+| `POST /api/extract-resume` | Node | PDF/DOCX text extraction |
+| `POST /api/download-pdf/[type]` | Node | PDF download for resume or cover letter |
+
+### generate-documents request fields
+- `company`, `jobTitle`, `jobDescription`, `backgroundExperience` — required
+- `isFromUploadedFile` — boolean, affects resume prompt framing
+- `fitAnalysis` — pre-computed FitAnalysis from /api/analyze-fit (optional, skips re-analysis)
+- `includeCoverLetter` — boolean (default false), skips cover letter phase when false
+
+## Model Selection
+
+Never hardcode model IDs. Use `getModels()` from `@/lib/models` — fetches from Anthropic API, cached 1hr via Next.js fetch.
+
+## Branch Naming
+
+All feature/fix branches must follow `claude/issue-{number}-{YYYYMMDD}-{HHMM}` so Vercel skips deployment on these branches.
+
 ## Development Guidelines
 
 - Always read TYPES.md for current type definitions before making database changes
 - Use existing patterns and conventions from the codebase
 - Follow the architecture rules defined in the repository context
+- Use `gh issue comment` to post progress updates on GitHub issues while working

--- a/app/api/generate-documents/route.ts
+++ b/app/api/generate-documents/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest) {
     console.log('[generate-documents] Auth check passed, userId:', userId);
 
     // Parse request body
-    const { company, jobTitle, jobDescription, backgroundExperience, isFromUploadedFile, fitAnalysis: precomputedAnalysis } = await req.json();
+    const { company, jobTitle, jobDescription, backgroundExperience, isFromUploadedFile, fitAnalysis: precomputedAnalysis, includeCoverLetter = false } = await req.json();
     console.log('[generate-documents] Parsed body:', { 
       company, 
       jobTitle, 
@@ -142,47 +142,45 @@ Output the resume in EXACTLY this format. Use • for bullet points. Separate ea
 
           sendEvent('resume_done');
 
-          // Phase 2: Generate cover letter
-          sendEvent('status', { message: 'Writing cover letter...' });
-          console.log('[generate-documents] Starting cover letter generation');
+          // Phase 2: Generate cover letter (optional)
+          if (includeCoverLetter) {
+            sendEvent('status', { message: 'Writing cover letter...' });
+            console.log('[generate-documents] Starting cover letter generation');
 
-          try {
-            const coverLetterStream = await anthropic.messages.create({
-            model: SONNET,
-            max_tokens: 2000,
-            system: `You are an expert cover letter writer. Write a professional 3-4 paragraph cover letter tailored to the role. Never invent experience. Use the generated resume content as context.`,
-            messages: [
-              {
-                role: 'user',
-                content: `Company: ${company}\nJob Title: ${jobTitle}\nJob Description: ${jobDescription}\n\nResume Content:\n${resumeText}\n\nPlease create a tailored cover letter.`
-              }
-            ],
-            stream: true
-            });
-            console.log('[generate-documents] Cover letter stream created successfully');
+            try {
+              const coverLetterStream = await anthropic.messages.create({
+                model: SONNET,
+                max_tokens: 2000,
+                system: `You are an expert cover letter writer. Write a professional 3-4 paragraph cover letter tailored to the role. Never invent experience. Use the generated resume content as context.`,
+                messages: [
+                  {
+                    role: 'user',
+                    content: `Company: ${company}\nJob Title: ${jobTitle}\nJob Description: ${jobDescription}\n\nResume Content:\n${resumeText}\n\nPlease create a tailored cover letter.`
+                  }
+                ],
+                stream: true
+              });
+              console.log('[generate-documents] Cover letter stream created successfully');
 
-            for await (const chunk of coverLetterStream) {
-              if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
-                const text = chunk.delta.text;
-                coverLetterText += text;
-                sendEvent('cover_letter_chunk', { content: text });
+              for await (const chunk of coverLetterStream) {
+                if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+                  const text = chunk.delta.text;
+                  coverLetterText += text;
+                  sendEvent('cover_letter_chunk', { content: text });
+                }
               }
+              console.log('[generate-documents] Cover letter generation completed, length:', coverLetterText.length);
+
+            } catch (coverLetterError) {
+              console.error('[generate-documents] Cover letter generation failed:', coverLetterError);
+              sendEvent('error', {
+                message: `Cover letter generation failed: ${coverLetterError instanceof Error ? coverLetterError.message : 'Unknown error'}`
+              });
+              return;
             }
-            console.log('[generate-documents] Cover letter generation completed, length:', coverLetterText.length);
 
-          } catch (coverLetterError) {
-            console.error('[generate-documents] Cover letter generation failed:', coverLetterError);
-            console.error('[generate-documents] Cover letter error message:', 
-              coverLetterError instanceof Error ? coverLetterError.message : String(coverLetterError));
-            console.error('[generate-documents] Cover letter error stack:', 
-              coverLetterError instanceof Error ? coverLetterError.stack : 'no stack');
-            sendEvent('error', { 
-              message: `Cover letter generation failed: ${coverLetterError instanceof Error ? coverLetterError.message : 'Unknown error'}` 
-            });
-            return;
+            sendEvent('cover_letter_done');
           }
-
-          sendEvent('cover_letter_done');
 
           // Save to Supabase
           console.log('[generate-documents] Starting Supabase save operation');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -106,6 +106,7 @@ export default function Home() {
   const [inputMethod, setInputMethod] = useState<'upload' | 'manual'>('upload');
   const [fitAnalysis, setFitAnalysis] = useState<FitAnalysis | null>(null);
   const [pendingFormData, setPendingFormData] = useState<FormData | null>(null);
+  const [includeCoverLetter, setIncludeCoverLetter] = useState(false);
   const [company, setCompany] = useState('');
   const [jobTitle, setJobTitle] = useState('');
   const [jobDescription, setJobDescription] = useState('');
@@ -214,7 +215,7 @@ export default function Home() {
       const response = await fetch('/api/generate-documents', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...pendingFormData, fitAnalysis }),
+        body: JSON.stringify({ ...pendingFormData, fitAnalysis, includeCoverLetter }),
       });
 
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -306,6 +307,7 @@ export default function Home() {
     setCoverLetterContent('');
     setFitAnalysis(null);
     setPendingFormData(null);
+    setIncludeCoverLetter(false);
     setErrorMessage('');
     setApplicationId(null);
     setCompany('');
@@ -475,7 +477,7 @@ export default function Home() {
                         className="flex-1"
                         onClick={handleGenerateDocuments}
                       >
-                        Generate Resume &amp; Cover Letter
+                        {includeCoverLetter ? 'Generate Resume & Cover Letter' : 'Generate Resume'}
                       </Button>
                       <Button
                         variant="outline"
@@ -653,7 +655,19 @@ export default function Home() {
                   </div>
                 </div>
 
-                <div className="text-center space-y-4 mb-8">
+                <div className="flex flex-col items-center space-y-4 mb-8">
+                  {/* Cover letter toggle */}
+                  <label className="flex items-center gap-3 cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked={includeCoverLetter}
+                      onChange={(e) => setIncludeCoverLetter(e.target.checked)}
+                      disabled={uiState === 'analyzing'}
+                      className="w-4 h-4 rounded border-border accent-primary"
+                    />
+                    <span className="text-sm text-muted-foreground">Also generate a cover letter</span>
+                  </label>
+
                   <Button
                     type="submit"
                     size="lg"
@@ -671,7 +685,7 @@ export default function Home() {
 
             {/* Live Preview Panels */}
             {(uiState === 'generating' || uiState === 'done') && (resumeContent || coverLetterContent) && (
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+              <div className={`grid grid-cols-1 ${includeCoverLetter ? 'lg:grid-cols-2' : ''} gap-8 mb-8`}>
                 {resumeContent && (
                   <div className="space-y-2">
                     <div className="flex items-center justify-between">
@@ -689,7 +703,7 @@ export default function Home() {
                   </div>
                 )}
 
-                {coverLetterContent && (
+                {includeCoverLetter && coverLetterContent && (
                   <div className="space-y-2">
                     <h3 className="text-lg font-semibold text-foreground">Cover Letter</h3>
                     <Textarea
@@ -714,6 +728,7 @@ export default function Home() {
                   >
                     Download Resume PDF
                   </Button>
+                  {includeCoverLetter && coverLetterContent && (
                   <Button
                     size="lg"
                     onClick={() => handleDownload('cover-letter')}
@@ -721,6 +736,7 @@ export default function Home() {
                   >
                     Download Cover Letter PDF
                   </Button>
+                  )}
                 </div>
                 <Button
                   variant="outline"


### PR DESCRIPTION
## Summary
- Checkbox below the form: "Also generate a cover letter" — unchecked by default
- When unchecked, the entire cover letter SSE phase is skipped (saves ~1 Sonnet call per generation)
- Modal generate button updates: "Generate Resume" vs "Generate Resume & Cover Letter"
- Cover letter preview panel and download button only rendered when it was generated
- Updated CLAUDE.md with API route docs, model selection rules, and branch naming convention

Closes #24

## Test plan
- [ ] Default: checkbox unchecked → only resume generated, cover letter UI hidden
- [ ] Check box → both generated, cover letter preview and download appear
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)