### PR TITLE
feat: application dashboard with history and re-download

### DIFF
--- a/app/dashboard/ApplicationCard.tsx
+++ b/app/dashboard/ApplicationCard.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { FileText, Download } from 'lucide-react';
+
+interface ApplicationCardProps {
+  id: string;
+  company: string;
+  jobTitle: string;
+  createdAt: string;
+  hasCoverLetter: boolean;
+}
+
+export default function ApplicationCard({
+  id,
+  company,
+  jobTitle,
+  createdAt,
+  hasCoverLetter,
+}: ApplicationCardProps) {
+  const [downloading, setDownloading] = useState<'resume' | 'cover-letter' | null>(null);
+  const [error, setError] = useState('');
+
+  const formattedDate = new Date(createdAt).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  const handleDownload = async (type: 'resume' | 'cover-letter') => {
+    setDownloading(type);
+    setError('');
+    try {
+      const res = await fetch(`/api/download-pdf/${type}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ applicationId: id }),
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const cd = res.headers.get('Content-Disposition');
+      a.download = cd?.match(/filename="(.+)"/)?.[1] ?? `${type}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch {
+      setError('Download failed. Please try again.');
+    } finally {
+      setDownloading(null);
+    }
+  };
+
+  return (
+    <div className="bg-card border border-border rounded-xl p-6 flex flex-col gap-4 hover:shadow-md transition-shadow">
+      <div>
+        <h3 className="text-lg font-semibold text-foreground">{company}</h3>
+        <p className="text-sm text-muted-foreground mt-0.5">{jobTitle}</p>
+        <p className="text-xs text-muted-foreground mt-2 flex items-center gap-1">
+          <FileText className="w-3 h-3" />
+          {formattedDate}
+        </p>
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <div className="flex flex-col gap-2 mt-auto">
+        <Button
+          size="sm"
+          onClick={() => handleDownload('resume')}
+          disabled={downloading !== null}
+          className="w-full"
+        >
+          <Download className="w-3.5 h-3.5 mr-2" />
+          {downloading === 'resume' ? 'Downloading…' : 'Download Resume'}
+        </Button>
+
+        {hasCoverLetter && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => handleDownload('cover-letter')}
+            disabled={downloading !== null}
+            className="w-full"
+          >
+            <Download className="w-3.5 h-3.5 mr-2" />
+            {downloading === 'cover-letter' ? 'Downloading…' : 'Download Cover Letter'}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,77 @@
+import { auth } from '@clerk/nextjs/server';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { supabaseServer } from '@/lib/supabase';
+import Navbar from '@/components/Navbar';
+import ApplicationCard from './ApplicationCard';
+import { Button } from '@/components/ui/button';
+import { PlusCircle, FileSearch } from 'lucide-react';
+
+export const metadata = { title: 'Dashboard — ResumeForge' };
+
+export default async function DashboardPage() {
+  const { userId } = await auth();
+  if (!userId) redirect('/sign-in');
+
+  const supabase = await supabaseServer();
+  const { data: applications, error } = await supabase
+    .from('applications')
+    .select('id, company, job_title, cover_letter_content, created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('[dashboard] Supabase error:', error.message);
+  }
+
+  const items = applications ?? [];
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar />
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <h2 className="text-2xl font-bold text-foreground">My Applications</h2>
+          <Link href="/">
+            <Button>
+              <PlusCircle className="w-4 h-4 mr-2" />
+              New Application
+            </Button>
+          </Link>
+        </div>
+
+        {/* Empty state */}
+        {items.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-24 text-center gap-4">
+            <FileSearch className="w-12 h-12 text-muted-foreground" />
+            <h3 className="text-lg font-semibold text-foreground">No applications yet</h3>
+            <p className="text-sm text-muted-foreground max-w-xs">
+              Generate your first tailored resume to see it here.
+            </p>
+            <Link href="/">
+              <Button>Generate Your First Resume</Button>
+            </Link>
+          </div>
+        )}
+
+        {/* Card grid */}
+        {items.length > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {items.map((app) => (
+              <ApplicationCard
+                key={app.id}
+                id={app.id}
+                company={app.company}
+                jobTitle={app.job_title}
+                createdAt={app.created_at}
+                hasCoverLetter={!!app.cover_letter_content}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useRef } from 'react';
-import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/nextjs';
+import { SignedIn, SignedOut, SignInButton } from '@clerk/nextjs';
+import Navbar from '@/components/Navbar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -325,32 +326,7 @@ export default function Home() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Top Navbar */}
-      <nav className="border-b border-border">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <h1 className="text-2xl font-bold text-foreground">ResumeForge</h1>
-            <div className="flex items-center">
-              <SignedOut>
-                <SignInButton>
-                  <Button variant="outline">Sign In</Button>
-                </SignInButton>
-              </SignedOut>
-              <SignedIn>
-                <UserButton
-                  appearance={{
-                    elements: {
-                      userButtonAvatarBox: "w-10 h-10",
-                      userButtonPopoverCard: "bg-popover border-border",
-                      userButtonPopoverText: "text-popover-foreground"
-                    }
-                  }}
-                />
-              </SignedIn>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <Navbar />
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/nextjs';
+import { Button } from '@/components/ui/button';
+
+export default function Navbar() {
+  return (
+    <nav className="border-b border-border">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <div className="flex items-center gap-8">
+            <Link href="/">
+              <h1 className="text-2xl font-bold text-foreground">ResumeForge</h1>
+            </Link>
+            <SignedIn>
+              <Link href="/dashboard" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+                Dashboard
+              </Link>
+            </SignedIn>
+          </div>
+
+          <div className="flex items-center">
+            <SignedOut>
+              <SignInButton>
+                <Button variant="outline">Sign In</Button>
+              </SignInButton>
+            </SignedOut>
+            <SignedIn>
+              <UserButton
+                appearance={{
+                  elements: {
+                    userButtonAvatarBox: 'w-10 h-10',
+                    userButtonPopoverCard: 'bg-popover border-border',
+                    userButtonPopoverText: 'text-popover-foreground',
+                  },
+                }}
+              />
+            </SignedIn>
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- `/dashboard` server page — fetches signed-in user's applications from Supabase (newest first)
- `ApplicationCard` client component — download resume/cover letter buttons, cover letter only shown when generated
- Shared `Navbar` component — Dashboard link added for signed-in users, replaces inline nav on home page
- Empty state with Generate CTA
- Responsive grid: 1 col mobile → 2 sm → 3 lg

Closes #15

## Test plan
- [ ] `/dashboard` loads and shows application cards
- [ ] Resume download works from dashboard
- [ ] Cover letter button only appears when one was generated
- [ ] Empty state shows with no applications
- [ ] Dashboard nav link works from home page
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)