### PR TITLE
fix: robust JSON extraction + analyze-fit logging

### DIFF
--- a/app/api/analyze-fit/route.ts
+++ b/app/api/analyze-fit/route.ts
@@ -48,12 +48,16 @@ Output valid JSON only, no markdown fences:
     });
 
     const text = response.content[0].type === 'text' ? response.content[0].text : '';
+    console.log('[analyze-fit] Raw model response length:', text.length);
+    console.log('[analyze-fit] Raw model response:', text.slice(0, 300));
+
     const fitAnalysis = parseStageJSON<FitAnalysis>(text);
+    console.log('[analyze-fit] Parsed successfully:', JSON.stringify(fitAnalysis).slice(0, 200));
 
     return Response.json(fitAnalysis);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error('[analyze-fit] Error:', message);
+    console.error('[analyze-fit] Failed:', message);
     return new Response(message, { status: 500 });
   }
 }

--- a/lib/pipeline-utils.ts
+++ b/lib/pipeline-utils.ts
@@ -1,16 +1,41 @@
-// Shared JSON parser for Claude API responses
-// Critical: Claude often returns JSON wrapped in markdown fences
-// Always use this instead of raw JSON.parse() on API responses
+// Shared JSON parser for Claude API responses.
+// Claude sometimes wraps JSON in markdown fences, adds preamble text,
+// or appends trailing commentary — this handles all of those cases.
 
 export function parseStageJSON<T>(input: string): T {
-  // Strip markdown code fences regardless of language tag, line endings, or trailing whitespace
-  const cleanInput = input.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+  const raw = input.trim();
+
+  // Strategy 1: strip markdown fences and try direct parse
+  const stripped = raw
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim();
 
   try {
-    return JSON.parse(cleanInput);
-  } catch (error) {
-    console.error('Failed to parse JSON:', error);
-    console.error('Input was:', input);
-    throw new Error(`Invalid JSON format: ${error}`);
+    return JSON.parse(stripped);
+  } catch {
+    // fall through to extraction
   }
+
+  // Strategy 2: extract the first complete {...} block.
+  // Handles preamble text, trailing commentary, and fence remnants.
+  const start = stripped.indexOf('{');
+  const end = stripped.lastIndexOf('}');
+
+  if (start !== -1 && end !== -1 && end > start) {
+    const extracted = stripped.slice(start, end + 1);
+    try {
+      return JSON.parse(extracted);
+    } catch {
+      // fall through to error
+    }
+  }
+
+  // Nothing worked — log the full raw output so we can debug
+  console.error('[parseStageJSON] All parse strategies failed.');
+  console.error('[parseStageJSON] Raw input length:', raw.length);
+  console.error('[parseStageJSON] Raw input (first 500 chars):', raw.slice(0, 500));
+  console.error('[parseStageJSON] Raw input (last 200 chars):', raw.slice(-200));
+
+  throw new Error(`Could not extract valid JSON from model response. Input length: ${raw.length}`);
 }


### PR DESCRIPTION
## Problem
`parseStageJSON` failed when the model appended trailing commentary after the closing `}` — e.g. `"Unexpected non-whitespace character after JSON at position 4702"`. The single regex strip strategy couldn't handle this.

## Fix
Two-strategy parse in `parseStageJSON`:
1. Strip markdown fences → `JSON.parse` (fast path)
2. Find first `{` + last `}` → extract and parse (handles trailing text, preamble, fence remnants)

Logs full raw input on failure so future issues are debuggable.

`analyze-fit` now logs raw response length, preview, and parse success on every call.

## Test plan
- [ ] Analyze Fit succeeds consistently
- [ ] Server logs show raw response preview on each call
- [ ] On failure, logs show full raw input for debugging
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)