### PR TITLE
fix: upload button, duplicate CL greeting, clean PDF filenames

### DIFF
--- a/app/api/download-pdf/cover-letter/route.ts
+++ b/app/api/download-pdf/cover-letter/route.ts
@@ -41,7 +41,6 @@ export async function POST(request: NextRequest) {
 
     const user = await currentUser()
     const fullName = user?.fullName || user?.firstName || 'User'
-    const lastName = user?.lastName || fullName.split(' ').pop() || 'User'
 
     const props = {
       coverLetterText: application.cover_letter_content,
@@ -53,9 +52,9 @@ export async function POST(request: NextRequest) {
     const element = createElement(CoverLetterPDF, props)
     const pdfBuffer = await renderToBuffer(element as React.ReactElement<any>)
 
-    const companyName = application.company.replace(/\s+/g, '_')
-    const role = application.job_title.replace(/\s+/g, '_')
-    const filename = `${lastName}_CoverLetter_${companyName}_${role}.pdf`
+    const companyName = application.company.replace(/[^a-zA-Z0-9]/g, '_')
+    const role = application.job_title.replace(/[^a-zA-Z0-9]/g, '_')
+    const filename = `CoverLetter_${companyName}_${role}.pdf`
 
     return new NextResponse(new Uint8Array(pdfBuffer), {
       headers: {

--- a/app/api/download-pdf/resume/route.ts
+++ b/app/api/download-pdf/resume/route.ts
@@ -41,7 +41,6 @@ export async function POST(request: NextRequest) {
 
     const user = await currentUser()
     const fullName = user?.fullName || user?.firstName || 'User'
-    const lastName = user?.lastName || fullName.split(' ').pop() || 'User'
 
     const props = {
       resumeText: application.resume_content,
@@ -53,9 +52,9 @@ export async function POST(request: NextRequest) {
     const element = createElement(ResumePDF, props)
     const pdfBuffer = await renderToBuffer(element as React.ReactElement<any>)
 
-    const companyName = application.company.replace(/\s+/g, '_')
-    const role = application.job_title.replace(/\s+/g, '_')
-    const filename = `${lastName}_Resume_${companyName}_${role}.pdf`
+    const companyName = application.company.replace(/[^a-zA-Z0-9]/g, '_')
+    const role = application.job_title.replace(/[^a-zA-Z0-9]/g, '_')
+    const filename = `Resume_${companyName}_${role}.pdf`
 
     return new NextResponse(new Uint8Array(pdfBuffer), {
       headers: {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -555,7 +555,7 @@ export default function Home() {
                       <Button
                         type="button"
                         variant={inputMethod === 'upload' ? 'default' : 'outline'}
-                        onClick={() => setInputMethod('upload')}
+                        onClick={() => { setInputMethod('upload'); fileInputRef.current?.click(); }}
                         disabled={uiState === 'analyzing'}
                         className="flex items-center space-x-2"
                       >

--- a/lib/pdf/CoverLetterPDF.tsx
+++ b/lib/pdf/CoverLetterPDF.tsx
@@ -58,11 +58,13 @@ export default function CoverLetterPDF({
     day: 'numeric'
   });
 
-  // Split cover letter text into paragraphs
+  // Split cover letter text into paragraphs, stripping any AI-generated
+  // greeting line (Dear ...,) since the template renders its own header
   const paragraphs = coverLetterText
     .split('\n\n')
-    .filter(paragraph => paragraph.trim().length > 0)
-    .map(paragraph => paragraph.trim());
+    .map(p => p.trim())
+    .filter(p => p.length > 0)
+    .filter(p => !/^dear\b/i.test(p));  // remove greeting — rendered below
 
   return (
     <Document>


### PR DESCRIPTION
## Bugs Fixed

**Upload button** — clicking "Upload Resume" toggle now directly opens the file picker via `fileInputRef.current?.click()`. Previously it only switched the view, requiring a second click on the dashed box.

**Duplicate greeting** — `CoverLetterPDF` hardcoded "Dear Hiring Manager," AND the AI-generated text started with its own greeting. Fixed by filtering out any `Dear...` paragraph from the AI content before rendering — the template greeting is the canonical one.

**PDF filenames** — were `Langley_Resume_Company_Role.pdf` (pulling `user.lastName` from Clerk). Changed to `Resume_Company_Role.pdf` and `CoverLetter_Company_Role.pdf`. Also tightened the sanitization regex to strip all non-alphanumeric chars, not just spaces.

## Test plan
- [ ] Upload Resume button opens file picker immediately
- [ ] Cover letter PDF has exactly one greeting
- [ ] Downloaded files named `Resume_*.pdf` / `CoverLetter_*.pdf` with no personal name

🤖 Generated with [Claude Code](https://claude.com/claude-code)