### PR TITLE
docs: rewrite README + update CLAUDE.md and TYPES.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,101 +2,161 @@
 
 This file contains important guidelines and rules for working with the ResumeForge codebase.
 
+## UI Terminology
+
+Use these terms consistently in all user-facing text:
+
+| Concept | Term to use |
+|---------|------------|
+| The page at `/dashboard` | "AI Resumes" |
+| The page at `/resumes` | "My Documents" |
+| A generated resume record | "resume" (not "application") |
+| Creating a new tailored resume | "Tailor New Resume" |
+| The library context picker | "Load from My Documents" |
+
+Never use "Dashboard", "Library", "application/s" (in UI copy), or "New Application" — these were replaced.
+
+---
+
 ## Database Schema Rules
 
 The schema defined in TYPES.md is the source of truth. Never reference columns that are not defined there.
 
-### Applications Table Schema
+### Applications Table
 Current valid columns:
 - `id` (string) - Primary key
 - `user_id` (string) - Foreign key to users
 - `company` (string) - Company name
 - `job_title` (string) - Position title
 - `job_description` (string) - Job posting description
-- `job_url` (string | null) - Link to job posting
+- `job_url` (string | null) - Link to job posting (saved when URL import is used)
 - `source_resume_id` (string | null) - ID of source resume used
-- `generated_resume` (string | null) - Generated resume content
-- `generated_cover_letter` (string | null) - Generated cover letter content
-- `status` (ApplicationStatus) - Application status enum
+- `resume_content` (string | null) - Generated resume text
+- `cover_letter_content` (string | null) - Generated cover letter text
+- `status` (ApplicationStatus) - Enum (kept in DB, not exposed in UI)
+- `fit_analysis` (Json | null) - Stored FitAnalysis object
 - `created_at` (string) - Auto-populated by Postgres default
 - `updated_at` (string) - Auto-updated by Postgres
 
-**If a new column is genuinely needed:**
-1. Add it to the schema definition in TYPES.md FIRST
-2. Write the migration SQL file in `/supabase/migrations/` 
-   following the existing naming convention (e.g. `003_add_column.sql`)
-3. Include a comment in the migration file with instructions:
-```sql
-   -- Run this in the Supabase SQL editor:
-   -- Dashboard → SQL Editor → paste and run
-   alter table applications add column if not exists your_column text;
-```
-4. Only then write the application code that uses the new column
+**Status editing is intentionally removed from the UI** — do not re-add it.
 
-**Never:**
-- Insert into columns that don't exist in the schema above
-- Add columns to insert/select statements before adding them
-  to the schema here and creating a migration file
-- Assume a column exists because it seems logical — check this
-  file first
+### Resumes Table (My Documents library)
+Current valid columns:
+- `id`, `user_id`, `title`, `content` (JSONB: `{ text: string, fileName?: string }`), `item_type`, `is_default`, `created_at`, `updated_at`
+- `item_type` values: `'resume' | 'cover_letter' | 'portfolio' | 'other'`
+- Only one item per user can have `is_default = true` (enforced by partial unique index)
+
+**If a new column is genuinely needed:**
+1. Add it to TYPES.md FIRST
+2. Write a migration in `/supabase/migrations/` (e.g. `006_add_column.sql`)
+3. Include instructions comment: `-- Run in Supabase SQL editor → Dashboard → SQL Editor`
+4. Only then write application code using the new column
+
+---
 
 ## API Routes
 
 | Route | Runtime | Purpose |
 |-------|---------|---------|
 | `POST /api/analyze-fit` | Node | Haiku fit analysis — returns JSON FitAnalysis |
-| `POST /api/generate-documents` | Edge | SSE stream — resume (+ optional cover letter) generation |
+| `POST /api/generate-documents` | Edge | SSE stream — resume (+ optional cover letter) |
+| `POST /api/fetch-job-posting` | Node | URL scrape — HTML extraction, company/title detection |
 | `POST /api/extract-resume` | Node | PDF/DOCX text extraction |
-| `POST /api/download-pdf/[type]` | Node | PDF download for resume or cover letter |
+| `POST /api/download-pdf/[type]` | Node | PDF generation and download |
+| `GET /api/resumes` | Node | List My Documents (default first, then created_at desc) |
+| `POST /api/resumes` | Node | Save new document to library |
 | `DELETE /api/applications` | Node | Bulk delete by `ids` array |
-| `DELETE /api/applications/[id]` | Node | Delete single application |
-| `GET /api/resumes` | Node | List library items (ordered: default first, then created_at desc) |
+| `DELETE /api/applications/[id]` | Node | Delete single resume record |
 
 ### generate-documents request fields
 - `company`, `jobTitle`, `jobDescription`, `backgroundExperience` — required
+- `jobUrl` — optional string, saved to `applications.job_url` if provided
 - `isFromUploadedFile` — boolean, affects resume prompt framing
-- `fitAnalysis` — pre-computed FitAnalysis from /api/analyze-fit (optional, skips re-analysis)
-- `includeCoverLetter` — boolean (default false), skips cover letter phase when false
+- `fitAnalysis` — pre-computed FitAnalysis (skips re-analysis)
+- `includeCoverLetter` — boolean (default false)
+- `additionalContext` — array of `{ title, type, text }` from My Documents
 
-### analyze-fit response shape
-Returns `FitAnalysis` (see `types/fit-analysis.ts`):
-- `strengths`, `gaps`, `suggestions` — arrays of `FitPoint { point: string, source?: string }`
-- `plannedImprovements` — string[] of 3-5 concrete resume changes the generator will make
-- `overallFit` — "Strong Fit" | "Good Fit" | "Stretch Role"
-- `roleType` — "technical" | "management" | "sales" | "customer_success" | "research" | "other"
+### fetch-job-posting behavior
+- Blocks `linkedin.com/jobs` URLs — returns `{ error, code: 'LINKEDIN_BLOCKED' }` with status 422
+- Strips scripts, styles, nav, header, footer from HTML
+- Truncates at application form markers ("Apply for this job", "Equal Employment Opportunity", etc.)
+- Detects company: `og:site_name` → title "at Company" pattern → Greenhouse/Lever/Workday URL patterns
+- Detects job title: `og:title` (stripped) → `<title>` tag fallback
+- Returns `{ jobDescription, company?, jobTitle? }`
+
+### analyze-fit response shape (FitAnalysis)
+- `strengths`, `gaps`, `suggestions` — `FitPoint[]` where `FitPoint = { point: string, source?: string }`
+- `plannedImprovements` — `string[]` of 3–5 concrete resume changes
+- `overallFit` — `"Strong Fit" | "Good Fit" | "Stretch Role"`
+- `roleType` — `"technical" | "management" | "sales" | "customer_success" | "research" | "other"`
+
+---
 
 ## Supabase Client
 
-Use `supabaseServer()` from `@/lib/supabase` — it is a **module-level singleton** (not async, no `await` needed).
-The service role key (`NEXT_PUBLIC_SUPABASE_SERVICE_KEY`) bypasses RLS. Always manually filter by `user_id` in every query.
+Use `supabaseServer()` from `@/lib/supabase` — **module-level singleton, not async**.
+
+```typescript
+const supabase = supabaseServer(); // correct — no await
+```
+
+The service role key (`NEXT_PUBLIC_SUPABASE_SERVICE_KEY`) bypasses RLS. **Always** manually filter by `user_id` in every query — never rely on RLS policies (Clerk's `auth.uid()` returns null in Supabase).
 
 **Never:**
-- Call `await supabaseServer()` — it is not a Promise
-- Use the anon key — RLS policies use `auth.uid()` which is always null for Clerk users
+- `await supabaseServer()` — it is not a Promise
+- Use `NEXT_PUBLIC_SUPABASE_ANON_KEY` — RLS will block all Clerk users
+
+---
 
 ## Model Selection
 
-Never hardcode model IDs. Use `getModels()` from `@/lib/models` — fetches from Anthropic API with 1hr in-memory cache and hardcoded fallback.
+Never hardcode model IDs. Use `getModels()` from `@/lib/models`:
+- Fetches available models from Anthropic API
+- Caches in memory for 1 hour
+- Falls back to hardcoded IDs (`claude-sonnet-4-6`, `claude-haiku-4-5-20251001`) on error
 
-## Dashboard
+```typescript
+const { SONNET, HAIKU } = await getModels();
+```
 
-- No application status editing — status was intentionally removed (too much manual overhead for users)
-- `ApplicationItem` type is exported from `app/dashboard/page.tsx` and imported by `ApplicationList`
-- Multi-select bulk delete is supported via checkboxes + destructive button
+---
 
-## ContextSelector behavior
+## AI Resumes Dashboard (`/dashboard`)
 
-- Auto-loads the default library item as the primary background on mount
-- Pre-selects the 3 most recent non-default items as additional context (accordion auto-expands)
-- `key={resetKey}` on the component in `app/page.tsx` — incrementing `resetKey` remounts it and re-fetches library on "Generate New Documents"
+- No status editing — removed intentionally
+- `ApplicationItem` type exported from `app/dashboard/page.tsx`, imported by `ApplicationList`
+- Multi-select bulk delete via checkboxes; single delete via trash icon on each card
+- Data fetched server-side in `DashboardPage`, passed to `ApplicationList` as `initialItems`
+
+---
+
+## My Documents / ContextSelector
+
+- `ContextSelector` auto-loads the default item as primary background on mount
+- Pre-selects up to 3 most recent non-default items as additional context; accordion auto-expands
+- `key={resetKey}` on `<ContextSelector>` in `app/page.tsx` — incrementing remounts and re-fetches
+- Additional context items appear in both analyze-fit and generate-documents prompts with source attribution
+
+---
+
+## Theme
+
+- Dark mode by default, toggled via `dark` class on `<html>`
+- Preference stored in `localStorage` under key `'theme'` (`'dark'` or `'light'`)
+- Inline script in `app/layout.tsx` applies preference before first paint (no flash)
+- Toggle button (Sun/Moon icon) lives in `Navbar.tsx` → `ThemeToggle` component
+
+---
 
 ## Branch Naming
 
-All feature/fix branches must follow `claude/issue-{number}-{YYYYMMDD}-{HHMM}` so Vercel skips deployment on these branches.
+All feature/fix branches: `claude/issue-{number}-{YYYYMMDD}-{HHMM}` — Vercel skips deployment on non-main branches.
+
+---
 
 ## Development Guidelines
 
-- Always read TYPES.md for current type definitions before making database changes
-- Use existing patterns and conventions from the codebase
-- Follow the architecture rules defined in the repository context
-- Use `gh issue comment` to post progress updates on GitHub issues while working
+- Read TYPES.md before any database changes
+- Run `npx tsc --noEmit` before committing — all PRs must be type-clean
+- Use `gh issue comment` to post progress updates on GitHub issues
+- Dev mode: `[Dev] Fill Test Data` button on home page pre-fills sample job + resume data

--- a/README.md
+++ b/README.md
@@ -1,36 +1,143 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# ResumeForge
 
-## Getting Started
+AI-powered resume and cover letter generator that tailors your documents to specific job postings. Paste a job description (or import it from a URL), provide your background, and ResumeForge analyzes your fit, surfaces gaps, and generates a polished, targeted resume — and optionally a cover letter — in seconds.
 
-First, run the development server:
+---
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+## What It Does
+
+### 1. Job Fit Analysis
+Before generating anything, ResumeForge runs a fit analysis using Claude Haiku:
+- Rates overall fit: **Strong Fit**, **Good Fit**, or **Stretch Role**
+- Lists specific strengths, gaps, and suggestions — each attributed to the source artifact they came from
+- Generates 3–5 **Planned Improvements**: concrete changes that will be made to the resume (e.g. "surface the 50% ticket resolution metric", "add missing keyword: GraphQL")
+- Detects role type (technical, management, sales, customer success, research) to tailor the analysis tone
+
+### 2. Document Generation
+After reviewing the fit analysis, the user approves generation. Claude Sonnet streams back:
+- A fully tailored resume formatted for the specific role and company
+- An optional cover letter (toggled before submission)
+- Both stream live to the page as they generate
+
+### 3. Job URL Auto-Import
+Users can paste a job posting URL instead of copying text manually:
+- Server-side page fetch with HTML stripping (scripts, nav, footer, forms)
+- Auto-detects company name from `og:site_name`, title patterns, and job board URLs (Greenhouse, Lever, Workday)
+- Auto-detects job title from `og:title`
+- Truncates at application form noise ("Apply for this job", "Equal Employment Opportunity", etc.)
+- LinkedIn URLs are blocked with a helpful inline message
+
+### 4. My Documents (Resume Library)
+A personal library of saved context artifacts:
+- Upload PDF or DOCX files — text is extracted server-side
+- Categorize items: Resume, Cover Letter, Portfolio, Other
+- Mark one item as **Default** — it auto-loads as the primary background on the home page
+- The 3 most recent non-default items are pre-selected as **additional context** for the AI, expanding the accordion automatically
+- Additional context items are appended to both the fit analysis and generation prompts, with source attribution on every insight
+
+### 5. AI Resumes Dashboard
+Saves every generated resume to Supabase:
+- Card view with company, job title, and date
+- Download resume or cover letter as PDF
+- Multi-select checkboxes for bulk delete
+- Single-card trash icon for individual delete
+
+### 6. PDF Downloads
+Generated documents can be downloaded as formatted PDFs directly from the dashboard or immediately after generation.
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | Next.js 14 (App Router) |
+| Auth | Clerk |
+| Database | Supabase (Postgres, service role key) |
+| AI | Anthropic Claude (Haiku for analysis, Sonnet for generation) |
+| Styling | Tailwind CSS + shadcn/ui |
+| Deployment | Vercel |
+
+---
+
+## Key Architecture Decisions
+
+- **No RLS** — Clerk and Supabase Auth are separate systems. The service role key is used and every query manually filters by `user_id`.
+- **Supabase singleton** — `supabaseServer()` returns a module-level singleton to avoid connection exhaustion on Vercel's serverless functions.
+- **Model cache** — `getModels()` caches Anthropic model IDs in memory for 1 hour with a hardcoded fallback, avoiding repeated API calls on every request.
+- **SSE streaming** — Document generation uses Server-Sent Events via the Edge runtime so the resume streams word-by-word to the UI.
+- **Fit analysis first** — Generation is always gated behind a fit review modal, so users see what the AI plans to change before committing.
+- **Dark mode default** — Theme is toggled via a `dark` class on `<html>`, defaulting to dark. Preference persists in `localStorage`. An inline script in `layout.tsx` prevents flash of wrong theme on load.
+
+---
+
+## Project Structure
+
+```
+app/
+  page.tsx                  # Home — job input form, fit analysis modal, generation flow
+  layout.tsx                # Root layout with Clerk provider and theme script
+  globals.css               # CSS variables for light/dark themes
+  dashboard/
+    page.tsx                # AI Resumes dashboard (server component)
+    ApplicationList.tsx     # Client component — multi-select, delete
+    ApplicationCard.tsx     # Individual resume card with download
+    loading.tsx             # Skeleton UI for Suspense boundary
+  resumes/
+    page.tsx                # My Documents library page (server component)
+    ResumeLibrary.tsx       # Client component — upload, edit, set default
+    loading.tsx             # Skeleton UI
+  api/
+    analyze-fit/            # POST — Haiku fit analysis, returns FitAnalysis JSON
+    generate-documents/     # POST — Sonnet streaming SSE (Edge runtime)
+    fetch-job-posting/      # POST — URL scrape, HTML extraction, company/title detection
+    extract-resume/         # POST — PDF/DOCX text extraction
+    download-pdf/[type]/    # POST — PDF generation and download
+    resumes/                # GET/POST/DELETE — library CRUD
+    applications/           # DELETE bulk
+    applications/[id]/      # DELETE single
+
+components/
+  Navbar.tsx                # Nav with theme toggle, signed-in links
+  ContextSelector.tsx       # Library picker — primary background + additional context
+
+lib/
+  supabase.ts               # Singleton Supabase client (service role)
+  models.ts                 # Cached model ID fetcher with fallback
+  pipeline-utils.ts         # Shared SSE helpers, JSON parser, context block builder
+
+types/
+  fit-analysis.ts           # FitAnalysis, FitPoint, OverallFit, RoleType
+  resume.ts                 # ResumeItem, ItemType, ITEM_TYPE_LABELS
+
+supabase/migrations/        # SQL migration files
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+---
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Environment Variables
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```env
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_SERVICE_KEY=   # Service role key (not anon)
+ANTHROPIC_API_KEY=
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=
+```
 
-## Learn More
+---
 
-To learn more about Next.js, take a look at the following resources:
+## Local Development
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+npm install
+npm run dev
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Open [http://localhost:3000](http://localhost:3000). The `[Dev] Fill Test Data` button on the home page pre-fills a sample job description and resume for quick testing.
 
-## Deploy on Vercel
+---
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Branch Naming
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Feature branches follow `claude/issue-{number}-{YYYYMMDD}-{HHMM}` so Vercel skips automatic deployment on non-main branches.

--- a/TYPES.md
+++ b/TYPES.md
@@ -1,52 +1,124 @@
 # Types and Interfaces
 
-Flat listing of all types, interfaces, and unions in the ResumeForge codebase.
+Current type definitions for the ResumeForge codebase. This is the source of truth for database columns and shared interfaces.
+
+---
 
 ## Database Types
 
-### Database
-- Main database schema interface with tables, views, functions, enums, and composite types
+### `Database`
+Main Supabase schema interface (`types/supabase.ts`). All table Row/Insert/Update types are derived from this.
 
-### Json  
-- Union type for JSON values: string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+### `Json`
+`string | number | boolean | null | { [key: string]: Json | undefined } | Json[]`
 
-### Users Table
-- Row: id (string), email (string), full_name (string | null), created_at (string), updated_at (string)
-- Insert: id (string), email (string), full_name (optional), created_at (optional), updated_at (optional) 
-- Update: all fields optional
+---
 
-### Resumes Table
-- Row: id (string), user_id (string), title (string), content (Json: { text: string, fileName?: string }), item_type (ItemType), is_default (boolean), created_at (string), updated_at (string)
-- Insert: id (optional), user_id (string), title (string), content (Json), item_type (optional, default 'resume'), is_default (optional, default false), created_at (optional), updated_at (optional)
-- Update: all fields optional
-- item_type values: 'resume' | 'cover_letter' | 'portfolio' | 'other'
-- Only one item per user can have is_default = true (enforced by partial unique index)
+## Table: `resumes` (My Documents library)
 
-### Applications Table  
-- Row: id (string), user_id (string), resume_id (string | null), job_title (string), company (string), job_description (string), resume_content (string | null), cover_letter_content (string | null), status (ApplicationStatus), application_date (string), fit_analysis (Json | null), created_at (string), updated_at (string)
-- Insert: id (optional), user_id (string), resume_id (optional), job_title (string), company (string), job_description (string), resume_content (optional), cover_letter_content (optional), status (optional), application_date (optional), fit_analysis (optional), created_at (optional), updated_at (optional)
-- Update: all fields optional
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | string | UUID, primary key |
+| `user_id` | string | Clerk user ID |
+| `title` | string | Display name |
+| `content` | Json | `{ text: string, fileName?: string }` — stored as JSONB |
+| `item_type` | ItemType | `'resume' \| 'cover_letter' \| 'portfolio' \| 'other'` |
+| `is_default` | boolean | Only one per user (partial unique index) |
+| `created_at` | string | ISO timestamp |
+| `updated_at` | string | ISO timestamp |
 
-## Model Types
+### `ItemType`
+`'resume' | 'cover_letter' | 'portfolio' | 'other'`
 
-### ModelType
-- Union of SONNET and HAIKU model strings
+### `ITEM_TYPE_LABELS`
+Display labels map: `{ resume: 'Resume', cover_letter: 'Cover Letter', portfolio: 'Portfolio', other: 'Other' }`
 
-### MODELS
-- Object containing SONNET: 'claude-3-5-sonnet-20241022', HAIKU: 'claude-3-5-haiku-20241022'
+### `ResumeItem`
+```typescript
+{
+  id: string
+  user_id: string
+  title: string
+  content: { text: string; fileName?: string }
+  item_type: ItemType
+  is_default: boolean
+  created_at: string
+  updated_at: string
+}
+```
 
-## Application Status
+---
 
-### ApplicationStatus
-- Union type: 'applied' | 'interviewing' | 'offered' | 'rejected' | 'withdrawn'
+## Table: `applications` (AI Resumes)
 
-## Fit Analysis Types
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | string | UUID, primary key |
+| `user_id` | string | Clerk user ID |
+| `company` | string | Company name |
+| `job_title` | string | Position title |
+| `job_description` | string | Full job posting text |
+| `job_url` | string \| null | Source URL if imported |
+| `source_resume_id` | string \| null | Library item used as base |
+| `resume_content` | string \| null | Generated resume text |
+| `cover_letter_content` | string \| null | Generated cover letter text |
+| `status` | ApplicationStatus | Not shown in UI, kept in DB |
+| `fit_analysis` | Json \| null | Stored `FitAnalysis` object |
+| `created_at` | string | ISO timestamp |
+| `updated_at` | string | ISO timestamp |
 
-### OverallFit
-- Union type: 'Strong Fit' | 'Good Fit' | 'Stretch Role'
+### `ApplicationStatus`
+`'applied' | 'interviewing' | 'offered' | 'rejected' | 'withdrawn'`
+> Status is stored in the database but intentionally not exposed in the UI.
 
-### RoleType
-- Union type: 'technical' | 'management' | 'sales' | 'customer_success' | 'research' | 'other'
+### `ApplicationItem` (dashboard display type)
+Exported from `app/dashboard/page.tsx`:
+```typescript
+{
+  id: string
+  company: string
+  job_title: string
+  cover_letter_content: string | null
+  created_at: string
+}
+```
 
-### FitAnalysis
-- Interface: overallFit (OverallFit), strengths (string[]), gaps (string[]), suggestions (string[]), roleType (RoleType)
+---
+
+## Fit Analysis Types (`types/fit-analysis.ts`)
+
+### `OverallFit`
+`'Strong Fit' | 'Good Fit' | 'Stretch Role'`
+
+### `RoleType`
+`'technical' | 'management' | 'sales' | 'customer_success' | 'research' | 'other'`
+
+### `FitPoint`
+```typescript
+{
+  point: string      // the insight text
+  source?: string    // artifact name it came from ("Primary Resume" or library item title)
+}
+```
+
+### `FitAnalysis`
+```typescript
+{
+  overallFit: OverallFit
+  strengths: FitPoint[]
+  gaps: FitPoint[]
+  suggestions: FitPoint[]
+  plannedImprovements: string[]   // 3–5 concrete resume changes the generator will make
+  roleType: RoleType
+}
+```
+
+---
+
+## Model Types (`lib/models.ts`)
+
+### Current model IDs
+- `SONNET`: `claude-sonnet-4-6` (used for document generation)
+- `HAIKU`: `claude-haiku-4-5-20251001` (used for fit analysis)
+
+> Never hardcode these. Use `getModels()` which fetches from the Anthropic API with a 1-hour in-memory cache and hardcoded fallback.


### PR DESCRIPTION
## Summary
- **README.md** — replaced the default Next.js boilerplate with a full project overview: what the app does (fit analysis, document generation, URL import, My Documents library, AI Resumes dashboard, PDF downloads), tech stack table, key architecture decisions, full project structure, env vars, and local dev guide
- **CLAUDE.md** — added UI terminology table (My Documents, AI Resumes, etc.), fetch-job-posting behavior docs, dark mode/theme rules, updated API route table, corrected applications table columns, clarified Supabase singleton usage
- **TYPES.md** — updated FitAnalysis to reflect current shape (FitPoint with source, plannedImprovements), added ApplicationItem dashboard type, correct current model IDs, ResumeItem and ITEM_TYPE_LABELS, reformatted as reference tables

## Test plan
- [ ] README renders correctly on GitHub
- [ ] All described features match what's actually in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)