### PR TITLE
fix: shorten nav labels on mobile to prevent wrapping

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -48,10 +48,12 @@ export default function Navbar() {
             </Link>
             <SignedIn>
               <Link href="/dashboard" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-                AI Resumes
+                <span className="hidden sm:inline">AI Resumes</span>
+                <span className="sm:hidden">Resumes</span>
               </Link>
               <Link href="/resumes" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-                My Documents
+                <span className="hidden sm:inline">My Documents</span>
+                <span className="sm:hidden">Docs</span>
               </Link>
             </SignedIn>
           </div>


### PR DESCRIPTION
"AI Resumes" → "Resumes" and "My Documents" → "Docs" below sm breakpoint.