### PR TITLE
Add /api/me endpoint for extension auth

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,0 +1,14 @@
+import { auth, currentUser } from '@clerk/nextjs/server';
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return new Response('Unauthorized', { status: 401 });
+
+  const user = await currentUser();
+  return Response.json({
+    id: userId,
+    name: user?.fullName ?? user?.firstName ?? '',
+    email: user?.emailAddresses[0]?.emailAddress ?? '',
+    imageUrl: user?.imageUrl ?? null,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds \`GET /api/me\` route that returns \`{ id, name, email, imageUrl }\` for the authenticated Clerk user
- Used by the ResumeForge Chrome extension to gate the UI behind auth on load and display the user's profile in the side panel header

## Test plan
- [ ] Sign in to ResumeForge and call \`GET /api/me\` — should return user info
- [ ] Call without a session — should return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)