### PR TITLE
feat: base resume — create and maintain a master resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Current valid columns:
 | `POST /api/interview-prep` | Node | Haiku — generates 8 interview questions across 6 categories; saves to `applications.interview_prep`; returns `InterviewPrep` |
 | `POST /api/log-event` | Node | Server-side event logging — writes JSON to Vercel function logs; always returns 200 |
 | `POST /api/resume-chat` | Node | Sonnet non-streaming — AI chat for refining a generated resume; parses `CHANGE:` vs `ANSWER:` response format; on change, updates `applications.resume_content` and `applications.chat_history` in Supabase |
+| `POST /api/generate-base-resume` | Node | Sonnet non-streaming — accepts `documentIds[]`, fetches documents from Supabase, builds comprehensive base resume; returns `{ resumeText: string }` |
+| `POST /api/base-resume-chat` | Node | Sonnet non-streaming — AI chat for refining base resume; parses `CHANGE:` vs `ANSWER:`; does NOT save to DB (caller saves explicitly); returns `{ type, content }` |
 | `POST /api/interview/generate` | Node | Sonnet non-streaming call — builds experience doc from interview transcript; returns `{ document: string }` |
 | `GET /api/interview/sessions` | Node | Fetch most recent `draft` session for current user; returns `{ session }` (null if none) |
 | `POST /api/interview/sessions` | Node | Create a new draft session; returns `{ id }` |
@@ -155,7 +157,8 @@ const { SONNET, HAIKU } = await getModels();
 - `ApplicationCard` shows a `Target` icon (primary color = prep exists, muted = not yet generated) — clicking triggers `POST /api/interview-prep` if null, then opens `InterviewPrepPanel` in a modal
 - `ApplicationCard` shows a `ScrollText` icon — opens a modal with the formatted job description (`FormattedJD` component)
 - `components/FitAnalysisModal.tsx` — reusable modal used on both home page (with `actions` slot for Generate/Start Over) and dashboard cards; handles Escape key, backdrop click, graceful fallback if data malformed; shows top 3 items per section by default with a chevron expand toggle; items are ranked most-impactful-first by the API prompt
-- `components/InlinePDFViewer.tsx` — inline PDF iframe (US Letter aspect ratio) rendered via `BlobProvider`; shown post-generation replacing the textarea; "Edit text" toggle switches back; auto-updates when `resumeContent` prop changes
+- `components/InlinePDFViewer.tsx` — inline PDF iframe (US Letter aspect ratio) rendered via `BlobProvider`; shown post-generation replacing the textarea; "Edit text" toggle switches back; auto-updates when `resumeContent` prop changes; reused in BaseResumeCreator (pass empty strings for company/jobTitle)
+- `components/BaseResumeCreator.tsx` — 3-step flow (select docs → generate → review); inline PDF + chat panel + explicit save; edit mode loaded via `?id=` query param from My Profile; saves to `resumes` table with `item_type: 'base_resume'`
 - `components/ResumeChatPanel.tsx` — post-generation resume chat; parses `CHANGE:` vs `ANSWER:` response format; "Fit to 1 page" and "Fit to 2 pages" quick-action chips; saves changes to `applications.resume_content` and `applications.chat_history`
 
 ## Resume Generation — Output Format

--- a/TYPES.md
+++ b/TYPES.md
@@ -22,16 +22,18 @@ Main Supabase schema interface (`types/supabase.ts`). All table Row/Insert/Updat
 | `user_id` | string | Clerk user ID |
 | `title` | string | Display name |
 | `content` | Json | `{ text: string, fileName?: string }` — stored as JSONB |
-| `item_type` | ItemType | `'resume' \| 'cover_letter' \| 'portfolio' \| 'other'` |
+| `item_type` | ItemType | `'resume' \| 'cover_letter' \| 'portfolio' \| 'other' \| 'base_resume'` |
 | `is_default` | boolean | Only one per user (partial unique index) |
 | `created_at` | string | ISO timestamp |
 | `updated_at` | string | ISO timestamp |
 
 ### `ItemType`
-`'resume' | 'cover_letter' | 'portfolio' | 'other'`
+`'resume' | 'cover_letter' | 'portfolio' | 'other' | 'base_resume'`
+
+`base_resume` is the user's master resume — always `is_default: true`, stored with title `'Base Resume'`. Not shown in ContextSelector or document list; managed separately via `/base-resume` page.
 
 ### `ITEM_TYPE_LABELS`
-Display labels map: `{ resume: 'Resume', cover_letter: 'Cover Letter', portfolio: 'Portfolio', other: 'Other' }`
+Display labels map: `{ resume: 'Resume', cover_letter: 'Cover Letter', portfolio: 'Portfolio', other: 'Other', base_resume: 'Base Resume' }`
 
 ### `ResumeItem`
 ```typescript

--- a/app/api/base-resume-chat/route.ts
+++ b/app/api/base-resume-chat/route.ts
@@ -1,0 +1,67 @@
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest } from 'next/server';
+import { Anthropic } from '@anthropic-ai/sdk';
+import { getModels } from '@/lib/models';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) return new Response('Unauthorized', { status: 401 });
+
+    const { resumeText, message, chatHistory = [] } = await req.json() as {
+      resumeText: string;
+      message: string;
+      chatHistory: ChatMessage[];
+    };
+
+    if (!resumeText || !message) return new Response('resumeText and message required', { status: 400 });
+
+    const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+    const { SONNET } = await getModels();
+
+    const history = chatHistory.slice(-10).map(m => ({
+      role: m.role as 'user' | 'assistant',
+      content: m.content,
+    }));
+
+    const response = await anthropic.messages.create({
+      model: SONNET,
+      max_tokens: 6000,
+      system: `You are a resume writing expert helping the user refine their base resume — a comprehensive master resume that covers their full career history.
+
+The user's current base resume:
+<base_resume>
+${resumeText}
+</base_resume>
+
+Rules:
+- If the user asks you to make a change, respond with CHANGE: followed by the complete updated resume text
+- If the user asks a question or wants advice (no change needed), respond with ANSWER: followed by your response
+- When making changes, preserve ALL experience — this is a base resume, do not remove roles or cut content unless the user explicitly asks
+- Apply the same bullet point rules: specific metrics, no hedging, no repeated action verbs, max 180 chars per bullet
+- Never use CHANGE: and ANSWER: in the same response`,
+      messages: [
+        ...history,
+        { role: 'user', content: message },
+      ],
+    });
+
+    const text = response.content[0].type === 'text' ? response.content[0].text : '';
+
+    if (text.startsWith('CHANGE:')) {
+      return Response.json({ type: 'change', content: text.slice('CHANGE:'.length).trim() });
+    } else {
+      const content = text.startsWith('ANSWER:') ? text.slice('ANSWER:'.length).trim() : text;
+      return Response.json({ type: 'answer', content });
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[base-resume-chat]', msg);
+    return new Response(msg, { status: 500 });
+  }
+}

--- a/app/api/generate-base-resume/route.ts
+++ b/app/api/generate-base-resume/route.ts
@@ -1,0 +1,70 @@
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest } from 'next/server';
+import { Anthropic } from '@anthropic-ai/sdk';
+import { getModels } from '@/lib/models';
+import { supabaseServer } from '@/lib/supabase';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) return new Response('Unauthorized', { status: 401 });
+
+    const { documentIds } = await req.json() as { documentIds: string[] };
+    if (!documentIds?.length) return new Response('documentIds required', { status: 400 });
+
+    const supabase = supabaseServer();
+    const { data: docs, error } = await supabase
+      .from('resumes')
+      .select('title, content, item_type')
+      .eq('user_id', userId)
+      .in('id', documentIds);
+
+    if (error || !docs?.length) return new Response('Documents not found', { status: 404 });
+
+    const combinedContext = docs
+      .map(d => {
+        const raw = d.content as unknown;
+        const text = typeof raw === 'string' ? JSON.parse(raw).text : (raw as { text: string }).text;
+        return `=== ${d.title} (${d.item_type}) ===\n${text}`;
+      })
+      .join('\n\n');
+
+    const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+    const { SONNET } = await getModels();
+
+    const response = await anthropic.messages.create({
+      model: SONNET,
+      max_tokens: 8000,
+      system: `You are an expert resume writer. Based on the candidate's uploaded experience documents, create a comprehensive base resume that captures their full career history.
+
+This is NOT a tailored resume — it should include everything. Hiring managers won't see this directly; it serves as the source of truth for generating tailored versions.
+
+Rules:
+- Include ALL roles with full detail — more is better here
+- Use the structured format with headers: NAME:, SUMMARY:, EXPERIENCE:, SKILLS:, EDUCATION:
+- Write bullets that are specific, metric-driven, and achievement-focused
+- Do not filter for any specific role type — include everything
+- Err heavily on the side of more detail not less
+- Bullet point rules:
+  • No repeated action verbs within a role — use a wide variety
+  • No hedging qualifiers ("Informally led", "Helped with", "Somewhat", "Assisted in leading")
+  • If they led, they led. Reframe confidently: "Helped lead a team" → "Co-led a team of N"
+  • Max 180 characters per bullet
+  • Action verb + what you did + outcome/impact format
+  • Most recent/primary role: 8-10 bullets; supporting roles: 6-8; early career: 4-5
+
+Output the resume text only — no markdown fences, no commentary.`,
+      messages: [{
+        role: 'user',
+        content: `Build a comprehensive base resume from these documents:\n\n${combinedContext}`,
+      }],
+    });
+
+    const resumeText = response.content[0].type === 'text' ? response.content[0].text : '';
+    return Response.json({ resumeText });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[generate-base-resume]', msg);
+    return new Response(msg, { status: 500 });
+  }
+}

--- a/app/base-resume/page.tsx
+++ b/app/base-resume/page.tsx
@@ -1,0 +1,49 @@
+import { auth } from '@clerk/nextjs/server';
+import { redirect } from 'next/navigation';
+import { supabaseServer } from '@/lib/supabase';
+import Navbar from '@/components/Navbar';
+import BaseResumeCreator from '@/components/BaseResumeCreator';
+import { ResumeItem } from '@/types/resume';
+
+export const metadata = { title: 'Base Resume — ResumeForge' };
+
+export default async function BaseResumePage({
+  searchParams,
+}: {
+  searchParams: { id?: string };
+}) {
+  const { userId } = await auth();
+  if (!userId) redirect('/sign-in');
+
+  const supabase = supabaseServer();
+  const { data } = await supabase
+    .from('resumes')
+    .select('id, user_id, title, content, item_type, is_default, created_at, updated_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  const items = (data ?? []).map((item: any) => ({
+    ...item,
+    content: typeof item.content === 'string' ? JSON.parse(item.content) : item.content,
+  })) as ResumeItem[];
+
+  const existingBaseResume = items.find(i => i.item_type === 'base_resume') ?? null;
+  const sourceDocuments = items.filter(i => i.item_type !== 'base_resume');
+
+  // If ?id param present and matches existing base resume, load in edit mode
+  const editId = searchParams.id;
+  const editItem = editId ? items.find(i => i.id === editId) ?? null : null;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar />
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <BaseResumeCreator
+          sourceDocuments={sourceDocuments}
+          existingBaseResume={existingBaseResume}
+          editItem={editItem}
+        />
+      </main>
+    </div>
+  );
+}

--- a/app/resumes/ResumeLibrary.tsx
+++ b/app/resumes/ResumeLibrary.tsx
@@ -1,21 +1,23 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { ResumeItem, ItemType, ITEM_TYPE_LABELS } from '@/types/resume';
-import { Plus, Trash2, Star, Pencil, Upload, X, Check } from 'lucide-react';
+import { Plus, Trash2, Star, Pencil, Upload, X, Check, FileText, Sparkles } from 'lucide-react';
 import TipsPanel from '@/components/TipsPanel';
 
 interface Props {
   initialItems: ResumeItem[];
+  baseResume: ResumeItem | null;
 }
 
 type ModalMode = 'add' | 'edit' | null;
 
-export default function ResumeLibrary({ initialItems }: Props) {
+export default function ResumeLibrary({ initialItems, baseResume }: Props) {
   const [items, setItems] = useState<ResumeItem[]>(initialItems);
   const [modal, setModal] = useState<ModalMode>(null);
   const [editingItem, setEditingItem] = useState<ResumeItem | null>(null);
@@ -114,8 +116,52 @@ export default function ResumeLibrary({ initialItems }: Props) {
     setItems(prev => prev.filter(i => i.id !== item.id));
   };
 
+  const formattedDate = baseResume
+    ? new Date(baseResume.updated_at).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+    : null;
+
   return (
-    <div>
+    <div className="space-y-8">
+      {/* Base Resume Section */}
+      <div>
+        <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
+          <FileText className="w-4 h-4" /> Base Resume
+        </h3>
+        {baseResume ? (
+          <div className="border border-border rounded-xl p-5 bg-card space-y-3">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="font-medium text-foreground">{baseResume.title}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Last updated {formattedDate} · {(baseResume.content?.text?.length ?? 0).toLocaleString()} chars
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <Link href={`/base-resume?id=${baseResume.id}`}>
+                  <Button size="sm" variant="outline">Edit &amp; Refine</Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="border border-dashed border-border rounded-xl p-6 text-center space-y-3">
+            <Sparkles className="w-8 h-8 text-muted-foreground mx-auto" />
+            <div>
+              <p className="font-medium text-foreground">No base resume yet</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                A base resume is the master document all your tailored resumes are built from.
+                It takes about 2 minutes to create.
+              </p>
+            </div>
+            <Link href="/base-resume">
+              <Button>Create Base Resume →</Button>
+            </Link>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <h3 className="text-base font-semibold text-foreground mb-3">Context Documents</h3>
       <div className="flex items-center justify-between mb-6">
         <p className="text-sm text-muted-foreground">{items.length} saved item{items.length !== 1 ? 's' : ''}</p>
         <Button onClick={openAdd} title="Add a new resume or document to your library">
@@ -243,6 +289,7 @@ export default function ResumeLibrary({ initialItems }: Props) {
           </div>
         </div>
       )}
+      </div> {/* end Context Documents */}
     </div>
   );
 }

--- a/app/resumes/page.tsx
+++ b/app/resumes/page.tsx
@@ -24,6 +24,14 @@ export default async function ResumesPage() {
 
   if (error) console.error('[resumes page]', error.message);
 
+  const allItems = (data ?? []).map((item: any) => ({
+    ...item,
+    content: typeof item.content === 'string' ? JSON.parse(item.content) : item.content,
+  })) as ResumeItem[];
+
+  const baseResume = allItems.find(i => i.item_type === 'base_resume') ?? null;
+  const regularItems = allItems.filter(i => i.item_type !== 'base_resume');
+
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
@@ -34,9 +42,9 @@ export default async function ResumesPage() {
         </Link>
         <div className="flex items-center justify-between mb-8">
           <div>
-            <h2 className="text-2xl font-bold text-foreground">My Documents</h2>
+            <h2 className="text-2xl font-bold text-foreground">My Profile</h2>
             <p className="text-sm text-muted-foreground mt-1">
-              Saved resumes, cover letter examples, and other context artifacts
+              Your base resume and context documents
             </p>
           </div>
           <Link href="/interview">
@@ -48,7 +56,7 @@ export default async function ResumesPage() {
             </Button>
           </Link>
         </div>
-        <ResumeLibrary initialItems={(data ?? []) as unknown as ResumeItem[]} />
+        <ResumeLibrary initialItems={regularItems} baseResume={baseResume} />
       </main>
     </div>
   );

--- a/app/tailor/page.tsx
+++ b/app/tailor/page.tsx
@@ -137,9 +137,29 @@ export default function Home() {
   const [showPdfView, setShowPdfView] = useState(true);
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [pendingSaveFile, setPendingSaveFile] = useState<{ text: string; fileName: string } | null>(null);
+  const [usingBaseResume, setUsingBaseResume] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const originalResumeRef = useRef('');
+  const baseResumeLoadedRef = useRef(false);
+
+  // Auto-load base resume as background on mount
+  useEffect(() => {
+    if (baseResumeLoadedRef.current) return;
+    fetch('/api/resumes')
+      .then(r => r.ok ? r.json() : [])
+      .then((items: Array<{ item_type: string; content: { text: string } }>) => {
+        const base = items.find(i => i.item_type === 'base_resume');
+        if (base && !manualExperience) {
+          setManualExperience(base.content.text);
+          setInputMethod('manual');
+          setUsingBaseResume(true);
+          baseResumeLoadedRef.current = true;
+        }
+      })
+      .catch(() => {});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Capture original resume text the first time generation completes
   useEffect(() => {
@@ -787,11 +807,18 @@ get an AI-tailored, ATS-optimized resume and cover letter in seconds.
 
                   {/* Right Column - Your Background */}
                   <div id="tour-background" className="space-y-6">
-                    <h3 className="text-xl font-semibold text-foreground mb-4">Your Background</h3>
+                    <div className="flex items-center justify-between mb-4">
+                      <h3 className="text-xl font-semibold text-foreground">Your Background</h3>
+                      {usingBaseResume && (
+                        <span className="text-xs px-2.5 py-1 rounded-full bg-primary/10 text-primary font-medium">
+                          Using base resume
+                        </span>
+                      )}
+                    </div>
 
                     <ContextSelector
                       key={resetKey}
-                      onLoadBackground={text => { setInputMethod('manual'); setManualExperience(text); }}
+                      onLoadBackground={text => { setInputMethod('manual'); setManualExperience(text); setUsingBaseResume(false); }}
                       onAdditionalContextChange={setAdditionalContext}
                       disabled={uiState === 'analyzing'}
                     />

--- a/components/BaseResumeCreator.tsx
+++ b/components/BaseResumeCreator.tsx
@@ -1,0 +1,390 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import { ArrowLeft, Check, Loader2, Send, RotateCcw, MessageCircle, ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { ResumeItem } from '@/types/resume';
+import { useUser } from '@clerk/nextjs';
+
+const InlinePDFViewer = dynamic(() => import('@/components/InlinePDFViewer'), { ssr: false });
+
+type Step = 'select' | 'generating' | 'review';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  type?: 'change' | 'answer';
+}
+
+const QUICK_ACTIONS = [
+  { label: 'Add summary',     prompt: 'Add a strong 2-3 sentence professional summary at the top' },
+  { label: 'Tighten bullets', prompt: 'Tighten the language throughout — remove weak verbs and passive voice' },
+  { label: 'Fit to 2 pages',  prompt: 'Trim this resume to fit cleanly on two pages without losing key content. Tell me what you changed.' },
+  { label: 'More detail',     prompt: 'Expand the bullet points with more specific metrics and achievements' },
+];
+
+interface Props {
+  sourceDocuments: ResumeItem[];
+  existingBaseResume: ResumeItem | null;
+  editItem: ResumeItem | null;
+}
+
+export default function BaseResumeCreator({ sourceDocuments, existingBaseResume, editItem }: Props) {
+  const router = useRouter();
+  const { user } = useUser();
+  const candidateName = user?.fullName ?? user?.firstName ?? '';
+
+  // If in edit mode, start at review with existing text
+  const [step, setStep] = useState<Step>(editItem ? 'review' : 'select');
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(
+    new Set(sourceDocuments.filter(d => d.item_type === 'resume' || d.item_type === 'other').map(d => d.id))
+  );
+  const [resumeText, setResumeText] = useState(editItem?.content.text ?? '');
+  const [showTextarea, setShowTextarea] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [genError, setGenError] = useState('');
+  const [genProgress, setGenProgress] = useState('');
+
+  // Chat state
+  const [chatExpanded, setChatExpanded] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    { role: 'assistant', content: 'Your base resume is ready. Ask me to refine any section, add detail to a role, adjust bullet points, or make any other changes.', type: 'answer' },
+  ]);
+  const [chatInput, setChatInput] = useState('');
+  const [chatLoading, setChatLoading] = useState(false);
+  const chatHistoryRef = useRef<ChatMessage[]>([]);
+
+  const toggleDoc = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const handleGenerate = async () => {
+    if (!selectedIds.size) return;
+    setStep('generating');
+    setGenError('');
+    setGenProgress('Reading your documents…');
+
+    try {
+      await new Promise(r => setTimeout(r, 600));
+      setGenProgress('Extracting experience…');
+      await new Promise(r => setTimeout(r, 400));
+      setGenProgress('Writing your base resume…');
+
+      const res = await fetch('/api/generate-base-resume', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ documentIds: Array.from(selectedIds) }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const { resumeText: generated } = await res.json();
+      setResumeText(generated);
+      setStep('review');
+    } catch (err) {
+      setGenError(err instanceof Error ? err.message : 'Generation failed. Please try again.');
+      setStep('select');
+    }
+  };
+
+  const handleSend = async (overridePrompt?: string) => {
+    const msg = overridePrompt ?? chatInput.trim();
+    if (!msg || chatLoading) return;
+    setChatInput('');
+    setChatLoading(true);
+
+    const userMsg: ChatMessage = { role: 'user', content: msg };
+    setMessages(prev => [...prev, userMsg]);
+    chatHistoryRef.current = [...chatHistoryRef.current, userMsg];
+
+    try {
+      const res = await fetch('/api/base-resume-chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          resumeText,
+          message: msg,
+          chatHistory: chatHistoryRef.current.slice(-10),
+        }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const data = await res.json() as { type: 'change' | 'answer'; content: string };
+
+      const assistantMsg: ChatMessage = { role: 'assistant', content: data.content, type: data.type };
+      setMessages(prev => [...prev, assistantMsg]);
+      chatHistoryRef.current = [...chatHistoryRef.current, assistantMsg];
+
+      if (data.type === 'change') {
+        setResumeText(data.content);
+        setSaved(false);
+      }
+    } catch (err) {
+      const errMsg: ChatMessage = { role: 'assistant', content: 'Something went wrong. Please try again.', type: 'answer' };
+      setMessages(prev => [...prev, errMsg]);
+    } finally {
+      setChatLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!resumeText.trim()) return;
+    setSaving(true);
+    try {
+      const isUpdate = editItem?.item_type === 'base_resume';
+      if (isUpdate && editItem) {
+        await fetch(`/api/resumes/${editItem.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: 'Base Resume',
+            content: { text: resumeText },
+            item_type: 'base_resume',
+            is_default: true,
+          }),
+        });
+      } else {
+        await fetch('/api/resumes', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: 'Base Resume',
+            content: { text: resumeText },
+            item_type: 'base_resume',
+            is_default: true,
+          }),
+        });
+      }
+      setSaved(true);
+      setTimeout(() => router.push('/resumes'), 1000);
+    } catch {
+      // stay on page if save fails
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── Select step ───────────────────────────────────────────────
+  if (step === 'select') {
+    return (
+      <div className="max-w-xl mx-auto space-y-6">
+        <Link href="/resumes" className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
+          <ArrowLeft className="w-4 h-4" /> Back to My Profile
+        </Link>
+
+        <div>
+          <h2 className="text-2xl font-bold text-foreground mb-1">
+            {existingBaseResume ? 'Rebuild Your Base Resume' : 'Create Your Base Resume'}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            We&apos;ll build your master resume from your uploaded experience. Which documents should we use?
+          </p>
+        </div>
+
+        {genError && <p className="text-sm text-destructive">{genError}</p>}
+
+        {sourceDocuments.length === 0 ? (
+          <div className="text-center py-12 space-y-3">
+            <p className="text-muted-foreground">No documents found. Upload your resume first.</p>
+            <Link href="/resumes"><Button variant="outline">Go to My Profile</Button></Link>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2">
+              {sourceDocuments.map(doc => (
+                <label key={doc.id} className="flex items-center gap-3 p-3.5 border border-border rounded-lg cursor-pointer hover:bg-muted/40 transition-colors">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(doc.id)}
+                    onChange={() => toggleDoc(doc.id)}
+                    className="w-4 h-4 accent-primary"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-foreground truncate">{doc.title}</p>
+                    <p className="text-xs text-muted-foreground">{doc.item_type.replace('_', ' ')}</p>
+                  </div>
+                </label>
+              ))}
+            </div>
+
+            <div className="flex items-center justify-between pt-2">
+              <button
+                onClick={() => {
+                  const allIds = sourceDocuments.map(d => d.id);
+                  setSelectedIds(selectedIds.size === allIds.length ? new Set() : new Set(allIds));
+                }}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {selectedIds.size === sourceDocuments.length ? 'Deselect all' : 'Select all'}
+              </button>
+              <Button onClick={handleGenerate} disabled={!selectedIds.size}>
+                Continue →
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // ── Generating step ───────────────────────────────────────────
+  if (step === 'generating') {
+    return (
+      <div className="max-w-xl mx-auto flex flex-col items-center justify-center py-24 space-y-6">
+        <Loader2 className="w-10 h-10 animate-spin text-primary" />
+        <div className="text-center space-y-1">
+          <p className="font-medium text-foreground">{genProgress}</p>
+          <p className="text-sm text-muted-foreground">This takes about 20–30 seconds</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Review step ───────────────────────────────────────────────
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">Your Base Resume</h2>
+          {editItem
+            ? <p className="text-sm text-muted-foreground mt-0.5">Make any changes, then save</p>
+            : <p className="text-sm text-muted-foreground mt-0.5">Review, refine, and save as your master resume</p>
+          }
+        </div>
+        <Button onClick={handleSave} disabled={saving || saved}>
+          {saved
+            ? <><Check className="w-4 h-4 mr-2" />Saved!</>
+            : saving
+              ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Saving…</>
+              : <><Check className="w-4 h-4 mr-2" />Save as Base Resume</>
+          }
+        </Button>
+      </div>
+
+      {/* PDF preview / textarea toggle */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-medium text-foreground">Resume Preview</span>
+          <button
+            onClick={() => setShowTextarea(v => !v)}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {showTextarea ? 'Show PDF' : 'Edit text'}
+          </button>
+        </div>
+        {showTextarea ? (
+          <Textarea
+            value={resumeText}
+            onChange={e => { setResumeText(e.target.value); setSaved(false); }}
+            className="min-h-[500px] font-mono text-sm bg-background"
+          />
+        ) : (
+          <InlinePDFViewer
+            type="resume"
+            text={resumeText}
+            candidateName={candidateName}
+            company=""
+            jobTitle=""
+          />
+        )}
+      </div>
+
+      {/* Chat panel */}
+      <div className="border border-border rounded-xl overflow-hidden">
+        <button
+          onClick={() => setChatExpanded(v => !v)}
+          className="w-full flex items-center justify-between px-5 py-3.5 text-sm font-semibold text-foreground hover:bg-muted/50 transition-colors"
+        >
+          <span className="flex items-center gap-2"><MessageCircle className="w-4 h-4" /> Refine with AI</span>
+          <ChevronDown className={`w-4 h-4 transition-transform ${chatExpanded ? 'rotate-180' : ''}`} />
+        </button>
+
+        {chatExpanded && (
+          <div className="border-t border-border">
+            {/* Quick actions */}
+            <div className="flex gap-2 flex-wrap p-4 pb-0">
+              {QUICK_ACTIONS.map(a => (
+                <button
+                  key={a.label}
+                  onClick={() => handleSend(a.prompt)}
+                  disabled={chatLoading}
+                  className="text-xs px-3 py-1.5 rounded-full border border-border hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+                >
+                  {a.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Messages */}
+            <div className="p-4 space-y-3 max-h-64 overflow-y-auto">
+              {messages.map((m, i) => (
+                <div key={i} className={`flex gap-2 ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                  <div className={`max-w-[85%] text-sm px-3.5 py-2.5 rounded-xl ${
+                    m.role === 'user'
+                      ? 'bg-primary text-primary-foreground'
+                      : m.type === 'change'
+                        ? 'bg-green-500/10 text-foreground border border-green-500/20'
+                        : 'bg-muted text-foreground'
+                  }`}>
+                    {m.type === 'change' && <p className="text-xs text-green-600 mb-1 font-medium">✓ Resume updated</p>}
+                    <p className="whitespace-pre-wrap">{m.type === 'change' ? 'Resume updated. Review the changes above.' : m.content}</p>
+                  </div>
+                </div>
+              ))}
+              {chatLoading && (
+                <div className="flex gap-2 justify-start">
+                  <div className="bg-muted px-3.5 py-2.5 rounded-xl">
+                    <div className="flex gap-1">
+                      <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground animate-bounce" style={{ animationDelay: '0ms' }} />
+                      <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground animate-bounce" style={{ animationDelay: '150ms' }} />
+                      <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground animate-bounce" style={{ animationDelay: '300ms' }} />
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Input */}
+            <div className="p-4 pt-0 flex gap-2">
+              <Textarea
+                value={chatInput}
+                onChange={e => setChatInput(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend(); } }}
+                placeholder="Ask me to refine anything…"
+                className="min-h-[44px] max-h-32 text-sm resize-none bg-background"
+                disabled={chatLoading}
+              />
+              <Button size="sm" onClick={() => handleSend()} disabled={!chatInput.trim() || chatLoading} className="shrink-0 h-11">
+                <Send className="w-4 h-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between pt-2">
+        {!editItem && (
+          <button onClick={() => setStep('select')} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
+            <RotateCcw className="w-3.5 h-3.5" /> Regenerate
+          </button>
+        )}
+        <div className="ml-auto">
+          <Button onClick={handleSave} disabled={saving || saved} size="lg">
+            {saved
+              ? <><Check className="w-4 h-4 mr-2" />Saved!</>
+              : saving
+                ? <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Saving…</>
+                : <><Check className="w-4 h-4 mr-2" />Save as Base Resume</>
+            }
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ContextSelector.tsx
+++ b/components/ContextSelector.tsx
@@ -22,15 +22,17 @@ export default function ContextSelector({ onLoadBackground, onAdditionalContextC
     fetch('/api/resumes')
       .then(r => r.ok ? r.json() : [])
       .then((data: ResumeItem[]) => {
-        setItems(data);
+        // Exclude base_resume from context selector — handled separately in tailor page
+        const filtered = data.filter(i => i.item_type !== 'base_resume');
+        setItems(filtered);
         setLoaded(true);
-        const defaultItem = data.find(i => i.is_default) ?? data[0] ?? null;
+        const defaultItem = filtered.find(i => i.is_default) ?? filtered[0] ?? null;
         if (defaultItem) {
           setSelectedId(defaultItem.id);
           onLoadBackground(defaultItem.content.text);
         }
         // Pre-select all non-default items as additional context
-        const nonDefault = data.filter(i => !i.is_default);
+        const nonDefault = filtered.filter(i => !i.is_default);
         if (nonDefault.length > 0) {
           setAdditionalIds(new Set(nonDefault.map(i => i.id)));
           setExpanded(true);

--- a/types/resume.ts
+++ b/types/resume.ts
@@ -1,10 +1,11 @@
-export type ItemType = 'resume' | 'cover_letter' | 'portfolio' | 'other'
+export type ItemType = 'resume' | 'cover_letter' | 'portfolio' | 'other' | 'base_resume'
 
 export const ITEM_TYPE_LABELS: Record<ItemType, string> = {
   resume: 'Resume',
   cover_letter: 'Cover Letter Example',
   portfolio: 'Portfolio / Work Sample',
   other: 'Other',
+  base_resume: 'Base Resume',
 }
 
 export interface ResumeContent {


### PR DESCRIPTION
Closes #109

## Summary
- `'base_resume'` added to `ItemType` union in `types/resume.ts` and `TYPES.md`
- **`POST /api/generate-base-resume`** — Sonnet call that accepts `documentIds[]`, fetches content from Supabase, and builds a comprehensive master resume
- **`POST /api/base-resume-chat`** — Sonnet CHANGE/ANSWER parsing for refining the base resume; does not save to DB (user saves explicitly)
- **`/base-resume` page** — 3-step flow: source selection → animated generation → review (inline PDF preview + AI chat + Save button)
- **Edit mode** — `?id=<resumeId>` loads existing base resume into the review step
- **My Profile page** — base resume section at the top showing last-updated date with Edit & Refine link; Create CTA when none exists; page title updated to "My Profile"
- **ContextSelector** — filters out `base_resume` items (managed separately via the base resume page)
- **Tailor page** — auto-loads base resume as background on mount; shows "Using base resume" badge; clears when user switches to another document

## Test plan
- [ ] My Profile shows base resume section at top (create CTA if none exists)
- [ ] "Create Base Resume" opens `/base-resume`; source docs pre-selected by type
- [ ] Select/deselect docs and click Continue → animated progress → review step
- [ ] Review step: PDF renders, Edit text toggle works, chat refines resume
- [ ] "Save as Base Resume" saves with `item_type: 'base_resume'` and `is_default: true`, redirects to My Profile
- [ ] My Profile now shows base resume with last-updated date and Edit & Refine button
- [ ] "Edit & Refine" → `/base-resume?id=...` loads existing resume in review step
- [ ] Previous base resume demoted when new one saved (API clears `is_default`)
- [ ] Tailor page auto-populates background with base resume on load
- [ ] "Using base resume" badge shows; clears when switching to another doc via ContextSelector
- [ ] ContextSelector does not show base_resume in its dropdown
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)