### PR TITLE
Admin: user detail, API logs, email history/scheduling

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -5,13 +5,14 @@ import { useUser } from '@clerk/nextjs';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { AdminProvider, useAdminContext } from './AdminContext';
-import { LayoutDashboard, Bell, Lock, Eye, EyeOff } from 'lucide-react';
+import { LayoutDashboard, Bell, Lock, Eye, EyeOff, ScrollText } from 'lucide-react';
 
 const ADMIN_USER_ID = process.env.NEXT_PUBLIC_ADMIN_USER_ID ?? '';
 
 const NAV_ITEMS = [
   { href: '/admin', label: 'Overview', icon: LayoutDashboard },
   { href: '/admin/notifications', label: 'Notifications', icon: Bell },
+  { href: '/admin/logs', label: 'API Logs', icon: ScrollText },
 ];
 
 function AdminSecretGate({ children }: { children: React.ReactNode }) {

--- a/app/admin/logs/page.tsx
+++ b/app/admin/logs/page.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useAdminContext } from '../AdminContext';
+import { Loader2, RefreshCw, ChevronDown, ChevronUp, AlertCircle, User } from 'lucide-react';
+
+interface LogEntry {
+  id: string;
+  user_id: string | null;
+  route: string;
+  method: string;
+  status_code: number | null;
+  request_body: Record<string, unknown> | null;
+  response_summary: Record<string, unknown> | null;
+  error: string | null;
+  duration_ms: number | null;
+  created_at: string;
+  user: { email: string; full_name: string | null } | null;
+}
+
+const ROUTES = [
+  '', '/api/generate-documents', '/api/analyze-fit',
+  '/api/billing/create-checkout', '/api/resume-chat',
+];
+
+function statusColor(code: number | null) {
+  if (!code) return 'bg-zinc-800 text-zinc-400';
+  if (code < 300) return 'bg-emerald-900/40 text-emerald-400';
+  if (code < 400) return 'bg-blue-900/40 text-blue-400';
+  if (code < 500) return 'bg-amber-900/40 text-amber-400';
+  return 'bg-red-900/40 text-red-400';
+}
+
+function timeStr(dateStr: string) {
+  const d = new Date(dateStr);
+  return d.toLocaleString('en-US', {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  });
+}
+
+function ExpandedLog({ log }: { log: LogEntry }) {
+  return (
+    <div className="border-t border-zinc-800 bg-zinc-950 px-4 py-3 space-y-3 text-xs font-mono">
+      {log.user_id && (
+        <div>
+          <p className="text-zinc-500 mb-1 font-sans font-medium">User</p>
+          <p className="text-zinc-300">{log.user?.full_name || log.user?.email || log.user_id}</p>
+          {log.user?.full_name && <p className="text-zinc-500">{log.user.email}</p>}
+          <p className="text-zinc-600 break-all">{log.user_id}</p>
+        </div>
+      )}
+      {log.error && (
+        <div>
+          <p className="text-red-400 font-sans font-medium mb-1">Error</p>
+          <pre className="text-red-300 whitespace-pre-wrap break-all bg-red-950/20 rounded p-2">{log.error}</pre>
+        </div>
+      )}
+      {log.request_body && (
+        <div>
+          <p className="text-zinc-500 font-sans font-medium mb-1">Request body</p>
+          <pre className="text-zinc-400 whitespace-pre-wrap break-all bg-zinc-900 rounded p-2 overflow-auto max-h-48">
+            {JSON.stringify(log.request_body, null, 2)}
+          </pre>
+        </div>
+      )}
+      {log.response_summary && (
+        <div>
+          <p className="text-zinc-500 font-sans font-medium mb-1">Response summary</p>
+          <pre className="text-zinc-400 whitespace-pre-wrap break-all bg-zinc-900 rounded p-2 overflow-auto max-h-48">
+            {JSON.stringify(log.response_summary, null, 2)}
+          </pre>
+        </div>
+      )}
+      {!log.error && !log.request_body && !log.response_summary && (
+        <p className="text-zinc-600 font-sans">No additional data stored for this call.</p>
+      )}
+    </div>
+  );
+}
+
+export default function AdminLogsPage() {
+  const { secret } = useAdminContext();
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const [filterRoute, setFilterRoute] = useState('');
+  const [filterUserId, setFilterUserId] = useState('');
+  const [filterError, setFilterError] = useState<'' | 'true' | 'false'>('');
+
+  const load = useCallback((p: number) => {
+    if (!secret) return;
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(p) });
+    if (filterRoute) params.set('route', filterRoute);
+    if (filterUserId) params.set('userId', filterUserId);
+    if (filterError) params.set('hasError', filterError);
+    fetch(`/api/admin/logs?${params}`, { headers: { 'x-admin-secret': secret } })
+      .then(r => r.json())
+      .then(data => { setLogs(data.logs ?? []); setTotal(data.total ?? 0); setPage(p); })
+      .finally(() => setLoading(false));
+  }, [secret, filterRoute, filterUserId, filterError]);
+
+  useEffect(() => { load(1); }, [load]);
+
+  const totalPages = Math.max(1, Math.ceil(total / 50));
+
+  return (
+    <div className="space-y-6 max-w-5xl">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-zinc-100">API Logs</h1>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-zinc-500">{total} total</span>
+          <button
+            onClick={() => load(page)}
+            className="p-1.5 rounded hover:bg-zinc-800 text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3">
+        <select
+          value={filterRoute}
+          onChange={e => setFilterRoute(e.target.value)}
+          className="bg-zinc-900 border border-zinc-700 text-zinc-300 text-xs rounded px-2 py-1.5 focus:outline-none focus:border-zinc-500"
+        >
+          <option value="">All routes</option>
+          {ROUTES.filter(Boolean).map(r => (
+            <option key={r} value={r}>{r.replace('/api/', '')}</option>
+          ))}
+        </select>
+
+        <select
+          value={filterError}
+          onChange={e => setFilterError(e.target.value as '' | 'true' | 'false')}
+          className="bg-zinc-900 border border-zinc-700 text-zinc-300 text-xs rounded px-2 py-1.5 focus:outline-none focus:border-zinc-500"
+        >
+          <option value="">All statuses</option>
+          <option value="false">Success only</option>
+          <option value="true">Errors only</option>
+        </select>
+
+        <input
+          type="text"
+          placeholder="Filter by user ID"
+          value={filterUserId}
+          onChange={e => setFilterUserId(e.target.value)}
+          className="bg-zinc-900 border border-zinc-700 text-zinc-300 text-xs rounded px-2 py-1.5 focus:outline-none focus:border-zinc-500 w-52"
+        />
+
+        {(filterRoute || filterUserId || filterError) && (
+          <button
+            onClick={() => { setFilterRoute(''); setFilterUserId(''); setFilterError(''); }}
+            className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* Table */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="w-5 h-5 animate-spin text-zinc-600" />
+          </div>
+        ) : logs.length === 0 ? (
+          <div className="py-12 text-center text-zinc-600 text-sm">No logs found.</div>
+        ) : (
+          <>
+            {/* Header row */}
+            <div className="grid grid-cols-[80px_1fr_160px_80px_70px_24px] gap-2 px-4 py-2 border-b border-zinc-800 text-xs text-zinc-500 font-medium">
+              <span>Status</span>
+              <span>Route</span>
+              <span>User</span>
+              <span>Duration</span>
+              <span>Time</span>
+              <span />
+            </div>
+
+            {logs.map(log => (
+              <div key={log.id} className="border-b border-zinc-800/60 last:border-0">
+                <button
+                  onClick={() => setExpandedId(id => id === log.id ? null : log.id)}
+                  className="w-full grid grid-cols-[80px_1fr_160px_80px_70px_24px] gap-2 px-4 py-3 text-left hover:bg-zinc-800/30 transition-colors items-center"
+                >
+                  <span className={`text-xs px-1.5 py-0.5 rounded font-mono w-fit ${statusColor(log.status_code)}`}>
+                    {log.status_code ?? '?'}
+                  </span>
+                  <div className="min-w-0 flex items-center gap-2">
+                    <span className="text-xs text-zinc-300 font-mono truncate">
+                      {log.route.replace('/api/', '')}
+                    </span>
+                    {log.error && (
+                      <AlertCircle className="w-3.5 h-3.5 text-red-400 shrink-0" />
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    {log.user ? (
+                      <div className="flex items-center gap-1 min-w-0">
+                        <User className="w-3 h-3 text-zinc-600 shrink-0" />
+                        <span className="text-xs text-zinc-400 truncate">
+                          {log.user.full_name || log.user.email}
+                        </span>
+                      </div>
+                    ) : log.user_id ? (
+                      <span className="text-xs text-zinc-600 font-mono truncate block">{log.user_id.slice(0, 12)}…</span>
+                    ) : (
+                      <span className="text-xs text-zinc-700">anon</span>
+                    )}
+                  </div>
+                  <span className="text-xs text-zinc-500 font-mono">
+                    {log.duration_ms != null ? `${log.duration_ms}ms` : '—'}
+                  </span>
+                  <span className="text-xs text-zinc-600">
+                    {timeStr(log.created_at)}
+                  </span>
+                  {expandedId === log.id
+                    ? <ChevronUp className="w-3.5 h-3.5 text-zinc-600 shrink-0" />
+                    : <ChevronDown className="w-3.5 h-3.5 text-zinc-600 shrink-0" />
+                  }
+                </button>
+                {expandedId === log.id && <ExpandedLog log={log} />}
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-xs text-zinc-500">
+          <button
+            disabled={page === 1}
+            onClick={() => load(page - 1)}
+            className="px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 disabled:opacity-30 transition-colors"
+          >
+            ← Previous
+          </button>
+          <span>Page {page} of {totalPages} ({total} entries)</span>
+          <button
+            disabled={page >= totalPages}
+            onClick={() => load(page + 1)}
+            className="px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 disabled:opacity-30 transition-colors"
+          >
+            Next →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/notifications/page.tsx
+++ b/app/admin/notifications/page.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useAdminContext } from '../AdminContext';
 import type { NotificationType } from '@/lib/notifications';
-import { Loader2, ChevronDown, ChevronUp, Send, Eye, X } from 'lucide-react';
+import { Loader2, Send, Eye, X, PlayCircle, CheckCircle, Clock, History } from 'lucide-react';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
 
 const NOTIFICATION_LABELS: Record<NotificationType, string> = {
-  setup_experience: 'Set up experience — no docs uploaded',
-  first_tailor: 'First tailor nudge — has docs, no resumes',
-  add_more_experience: 'Add more experience — 1 doc, has resumes',
-  job_hunt_checkin: 'Job hunt check-in — inactive 14+ days',
-  try_extension: 'Try the extension — not used yet',
+  setup_experience: 'Set up experience',
+  first_tailor: 'First tailor nudge',
+  add_more_experience: 'Add more experience',
+  job_hunt_checkin: 'Job hunt check-in',
+  try_extension: 'Try the extension',
 };
 
 const NOTIFICATION_DESCRIPTIONS: Record<NotificationType, string> = {
@@ -18,8 +20,12 @@ const NOTIFICATION_DESCRIPTIONS: Record<NotificationType, string> = {
   first_tailor: 'Sent 48h after signup to users with docs but no tailored resumes.',
   add_more_experience: 'Sent 7d after signup to users with 1 doc and at least 1 resume.',
   job_hunt_checkin: 'Sent to users inactive for 14+ days who have tailored at least once.',
-  try_extension: 'Sent 3d after signup to users who haven\'t used the Chrome extension.',
+  try_extension: "Sent 3d after signup to users who haven't used the Chrome extension.",
 };
+
+const ALL_TYPES = Object.keys(NOTIFICATION_LABELS) as NotificationType[];
+
+// ── Types ────────────────────────────────────────────────────────────────────
 
 interface UserRow {
   id: string;
@@ -41,10 +47,31 @@ interface SendResult {
   error?: string;
 }
 
+interface HistoryRow {
+  id: string;
+  user_id: string;
+  notification_type: string;
+  sent_at: string;
+  user: { email: string; full_name: string | null } | null;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function timeAgo(dateStr: string) {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const h = Math.floor(diff / 3600000);
+  if (h < 1) return 'just now';
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
 function daysSince(dateStr: string) {
   const days = Math.floor((Date.now() - new Date(dateStr).getTime()) / (1000 * 60 * 60 * 24));
   return `${days}d ago`;
 }
+
+// ── Preview modal ────────────────────────────────────────────────────────────
 
 function PreviewModal({ type, secret, onClose }: { type: NotificationType; secret: string; onClose: () => void }) {
   const [html, setHtml] = useState<string | null>(null);
@@ -91,39 +118,195 @@ function PreviewModal({ type, secret, onClose }: { type: NotificationType; secre
   );
 }
 
-export default function NotificationsAdminPage() {
-  const { secret } = useAdminContext();
-  const [users, setUsers] = useState<UserRow[]>([]);
-  const [loading, setLoading] = useState(false);
+// ── History tab ──────────────────────────────────────────────────────────────
+
+function HistoryTab({ secret }: { secret: string }) {
+  const [history, setHistory] = useState<HistoryRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [filterType, setFilterType] = useState('');
+
+  const load = useCallback((p: number) => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(p) });
+    if (filterType) params.set('type', filterType);
+    fetch(`/api/admin/email-history?${params}`, { headers: { 'x-admin-secret': secret } })
+      .then(r => r.json())
+      .then(d => { setHistory(d.history ?? []); setTotal(d.total ?? 0); setPage(p); })
+      .finally(() => setLoading(false));
+  }, [secret, filterType]);
+
+  useEffect(() => { load(1); }, [load]);
+
+  const totalPages = Math.max(1, Math.ceil(total / 50));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-zinc-400">{total} emails sent total</p>
+        <select
+          value={filterType}
+          onChange={e => setFilterType(e.target.value)}
+          className="bg-zinc-900 border border-zinc-700 text-zinc-300 text-xs rounded px-2 py-1.5 focus:outline-none"
+        >
+          <option value="">All types</option>
+          {ALL_TYPES.map(t => (
+            <option key={t} value={t}>{NOTIFICATION_LABELS[t]}</option>
+          ))}
+        </select>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="w-4 h-4 animate-spin text-zinc-600" />
+        </div>
+      ) : history.length === 0 ? (
+        <p className="text-zinc-600 text-sm py-4">No emails sent yet.</p>
+      ) : (
+        <>
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800 text-left">
+                  <th className="px-4 py-2.5 text-xs text-zinc-500 font-medium">User</th>
+                  <th className="px-4 py-2.5 text-xs text-zinc-500 font-medium">Email type</th>
+                  <th className="px-4 py-2.5 text-xs text-zinc-500 font-medium">Sent</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.map((row, i) => (
+                  <tr key={row.id} className={`${i < history.length - 1 ? 'border-b border-zinc-800/50' : ''}`}>
+                    <td className="px-4 py-3">
+                      <p className="text-zinc-200 text-xs">{row.user?.full_name || row.user?.email || row.user_id}</p>
+                      {row.user?.full_name && <p className="text-zinc-600 text-xs">{row.user.email}</p>}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="text-xs px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400">
+                        {NOTIFICATION_LABELS[row.notification_type as NotificationType] ?? row.notification_type}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-zinc-500 text-xs">
+                      <p>{timeAgo(row.sent_at)}</p>
+                      <p className="text-zinc-700">{new Date(row.sent_at).toLocaleString()}</p>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between text-xs text-zinc-500">
+              <button disabled={page === 1} onClick={() => load(page - 1)}
+                className="px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 disabled:opacity-30 transition-colors">
+                ← Prev
+              </button>
+              <span>Page {page} of {totalPages}</span>
+              <button disabled={page >= totalPages} onClick={() => load(page + 1)}
+                className="px-3 py-1.5 rounded bg-zinc-800 hover:bg-zinc-700 disabled:opacity-30 transition-colors">
+                Next →
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Scheduled tab ────────────────────────────────────────────────────────────
+
+function ScheduledTab({ users, loading }: { users: UserRow[]; loading: boolean }) {
+  // Group eligible users by notification type
+  const byType: Record<NotificationType, UserRow[]> = {
+    setup_experience: [],
+    first_tailor: [],
+    add_more_experience: [],
+    job_hunt_checkin: [],
+    try_extension: [],
+  };
+
+  for (const user of users) {
+    for (const type of user.eligible) {
+      byType[type].push(user);
+    }
+  }
+
+  const totalScheduled = users.reduce((sum, u) => sum + u.eligible.length, 0);
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-zinc-400">
+        {totalScheduled} email{totalScheduled !== 1 ? 's' : ''} queued for the next cron run
+        {' '}
+        <span className="text-zinc-600">(daily at 14:00 UTC)</span>
+      </p>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-zinc-600 text-sm">
+          <Loader2 className="w-4 h-4 animate-spin" /> Loading…
+        </div>
+      ) : totalScheduled === 0 ? (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-6 text-center">
+          <CheckCircle className="w-8 h-8 text-green-400 mx-auto mb-2" />
+          <p className="text-zinc-400 text-sm font-medium">All caught up</p>
+          <p className="text-zinc-600 text-xs mt-1">No emails are scheduled to send right now.</p>
+        </div>
+      ) : (
+        ALL_TYPES.map(type => {
+          const queued = byType[type];
+          if (queued.length === 0) return null;
+          return (
+            <div key={type} className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+              <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800 bg-zinc-900/80">
+                <div>
+                  <p className="text-sm font-medium text-zinc-200">{NOTIFICATION_LABELS[type]}</p>
+                  <p className="text-xs text-zinc-600 mt-0.5">{NOTIFICATION_DESCRIPTIONS[type]}</p>
+                </div>
+                <span className="text-xs bg-blue-900/40 text-blue-400 px-2 py-0.5 rounded-full ml-3 shrink-0">
+                  {queued.length} pending
+                </span>
+              </div>
+              <table className="w-full text-xs">
+                <tbody>
+                  {queued.map((u, i) => (
+                    <tr key={u.id} className={`${i < queued.length - 1 ? 'border-b border-zinc-800/40' : ''}`}>
+                      <td className="px-4 py-2.5">
+                        <p className="text-zinc-300">{u.full_name || u.email}</p>
+                        {u.full_name && <p className="text-zinc-600">{u.email}</p>}
+                      </td>
+                      <td className="px-4 py-2.5 text-zinc-500">
+                        Joined {daysSince(u.created_at)}
+                      </td>
+                      <td className="px-4 py-2.5 text-zinc-500">
+                        {u.doc_count} docs · {u.tailor_count} resumes
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+// ── Send tab ─────────────────────────────────────────────────────────────────
+
+function SendTab({
+  secret, users, loading, onRefresh,
+}: { secret: string; users: UserRow[]; loading: boolean; onRefresh: () => void }) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [notificationType, setNotificationType] = useState<NotificationType>('setup_experience');
   const [force, setForce] = useState(false);
   const [sending, setSending] = useState(false);
   const [results, setResults] = useState<SendResult[] | null>(null);
-  const [error, setError] = useState('');
   const [showPreview, setShowPreview] = useState(false);
-  const [expandedUserId, setExpandedUserId] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (secret) fetchUsers();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [secret]);
-
-  async function fetchUsers() {
-    setLoading(true);
-    setError('');
-    try {
-      const res = await fetch('/api/admin/send-notification', {
-        headers: { 'x-admin-secret': secret },
-      });
-      if (!res.ok) { setError('Wrong secret or server error'); setLoading(false); return; }
-      const data = await res.json();
-      setUsers(data.users);
-    } catch {
-      setError('Failed to fetch users');
-    }
-    setLoading(false);
-  }
+  const [triggerRunning, setTriggerRunning] = useState(false);
+  const [triggerResult, setTriggerResult] = useState<{ sent: number; skipped: number; failed: number } | null>(null);
 
   const toggleAll = () => {
     if (selectedIds.size === users.length) setSelectedIds(new Set());
@@ -138,6 +321,7 @@ export default function NotificationsAdminPage() {
     });
   };
 
+  const eligibleCount = users.filter(u => u.eligible.includes(notificationType)).length;
   const selectEligible = () => {
     setSelectedIds(new Set(users.filter(u => u.eligible.includes(notificationType)).map(u => u.id)));
   };
@@ -154,42 +338,71 @@ export default function NotificationsAdminPage() {
     const data = await res.json();
     setResults(data.results);
     setSending(false);
-    fetchUsers();
+    onRefresh();
   }
 
-  const eligibleCount = users.filter(u => u.eligible.includes(notificationType)).length;
+  async function triggerCron() {
+    setTriggerRunning(true);
+    setTriggerResult(null);
+    const res = await fetch('/api/admin/trigger-notifications', {
+      method: 'POST',
+      headers: { 'x-admin-secret': secret },
+    });
+    const data = await res.json();
+    setTriggerResult({ sent: data.sent ?? 0, skipped: data.skipped ?? 0, failed: data.failed ?? 0 });
+    setTriggerRunning(false);
+    onRefresh();
+  }
+
   const successCount = results?.filter(r => r.ok).length ?? 0;
   const failCount = results?.filter(r => !r.ok).length ?? 0;
 
   return (
-    <div className="space-y-6 max-w-5xl">
+    <div className="space-y-5">
       {showPreview && <PreviewModal type={notificationType} secret={secret} onClose={() => setShowPreview(false)} />}
 
-      <div className="flex items-center justify-between">
-        <h1 className="text-lg font-semibold text-zinc-100">Notifications</h1>
+      {/* Run cron now */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-4 flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-zinc-200">Run automatic send now</p>
+          <p className="text-xs text-zinc-600 mt-0.5">
+            Sends all pending lifecycle emails to eligible users (same as the daily cron).
+          </p>
+          {triggerResult && (
+            <p className="text-xs mt-1.5">
+              <span className="text-green-400">{triggerResult.sent} sent</span>
+              <span className="text-zinc-600 mx-1.5">·</span>
+              <span className="text-zinc-500">{triggerResult.skipped} already sent</span>
+              {triggerResult.failed > 0 && (
+                <><span className="text-zinc-600 mx-1.5">·</span><span className="text-red-400">{triggerResult.failed} failed</span></>
+              )}
+            </p>
+          )}
+        </div>
         <button
-          onClick={fetchUsers}
-          disabled={loading}
-          className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors flex items-center gap-1"
+          onClick={triggerCron}
+          disabled={triggerRunning}
+          className="flex items-center gap-1.5 bg-zinc-700 hover:bg-zinc-600 disabled:opacity-50 text-white text-sm px-4 py-2 rounded shrink-0 transition-colors"
         >
-          {loading && <Loader2 className="w-3 h-3 animate-spin" />}
-          Refresh
+          {triggerRunning ? <Loader2 className="w-4 h-4 animate-spin" /> : <PlayCircle className="w-4 h-4" />}
+          {triggerRunning ? 'Sending…' : 'Run now'}
         </button>
       </div>
 
-      {error && <p className="text-red-400 text-sm">{error}</p>}
-
-      {/* Notification type selector + actions */}
+      {/* Manual send controls */}
       <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-5 space-y-4">
+        <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider">Manual send</p>
         <div className="flex flex-wrap gap-3 items-start">
           <div className="flex-1 min-w-[280px]">
-            <label className="block text-xs text-zinc-500 uppercase tracking-wider font-medium mb-1.5">Notification type</label>
+            <label className="block text-xs text-zinc-500 uppercase tracking-wider font-medium mb-1.5">
+              Notification type
+            </label>
             <select
               value={notificationType}
               onChange={e => { setNotificationType(e.target.value as NotificationType); setResults(null); }}
               className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-zinc-500 text-zinc-200"
             >
-              {(Object.keys(NOTIFICATION_LABELS) as NotificationType[]).map(t => (
+              {ALL_TYPES.map(t => (
                 <option key={t} value={t}>{NOTIFICATION_LABELS[t]}</option>
               ))}
             </select>
@@ -201,13 +414,9 @@ export default function NotificationsAdminPage() {
               onClick={() => setShowPreview(true)}
               className="flex items-center gap-1.5 text-xs px-3 py-2 rounded border border-zinc-700 hover:border-zinc-500 text-zinc-300 transition-colors"
             >
-              <Eye className="w-3.5 h-3.5" />
-              Preview email
+              <Eye className="w-3.5 h-3.5" /> Preview email
             </button>
-            <button
-              onClick={selectEligible}
-              className="text-xs text-blue-400 hover:text-blue-300 transition-colors text-left"
-            >
+            <button onClick={selectEligible} className="text-xs text-blue-400 hover:text-blue-300 transition-colors text-left">
               Select {eligibleCount} eligible
             </button>
           </div>
@@ -225,8 +434,7 @@ export default function NotificationsAdminPage() {
           >
             {sending
               ? <><Loader2 className="w-4 h-4 animate-spin" />Sending…</>
-              : <><Send className="w-4 h-4" />Send to {selectedIds.size} user{selectedIds.size !== 1 ? 's' : ''}</>
-            }
+              : <><Send className="w-4 h-4" />Send to {selectedIds.size} user{selectedIds.size !== 1 ? 's' : ''}</>}
           </button>
         </div>
       </div>
@@ -270,65 +478,61 @@ export default function NotificationsAdminPage() {
                 <th className="px-4 py-3 text-xs text-zinc-500 font-medium">User</th>
                 <th className="px-4 py-3 text-xs text-zinc-500 font-medium">Joined</th>
                 <th className="px-4 py-3 text-xs text-zinc-500 font-medium">Activity</th>
-                <th className="px-4 py-3 text-xs text-zinc-500 font-medium">Sent</th>
-                <th className="px-4 py-3 text-xs text-zinc-500 font-medium">Eligible</th>
+                <th className="px-4 py-3 text-xs text-zinc-500 font-medium">Already sent</th>
+                <th className="px-4 py-3 text-xs text-zinc-500 font-medium">Eligible for</th>
               </tr>
             </thead>
             <tbody>
-              {users.map((u, i) => {
-                const isExpanded = expandedUserId === u.id;
-                const isEligibleForCurrent = u.eligible.includes(notificationType);
-                return (
-                  <>
-                    <tr
-                      key={u.id}
-                      className={`border-b border-zinc-800/50 hover:bg-zinc-800/30 cursor-pointer transition-colors ${selectedIds.has(u.id) ? 'bg-blue-950/20' : ''}`}
-                      onClick={() => toggleUser(u.id)}
-                    >
-                      <td className="px-4 py-3" onClick={e => e.stopPropagation()}>
-                        <input
-                          type="checkbox"
-                          checked={selectedIds.has(u.id)}
-                          onChange={() => toggleUser(u.id)}
-                          className="accent-blue-500"
-                        />
-                      </td>
-                      <td className="px-4 py-3">
-                        <p className="text-zinc-200">{u.email}</p>
-                        {u.full_name && <p className="text-zinc-600 text-xs">{u.full_name}</p>}
-                      </td>
-                      <td className="px-4 py-3 text-zinc-500 text-xs">{daysSince(u.created_at)}</td>
-                      <td className="px-4 py-3 text-zinc-400 text-xs">
-                        <span>{u.doc_count} doc{u.doc_count !== 1 ? 's' : ''}</span>
-                        <span className="mx-1 text-zinc-700">·</span>
-                        <span>{u.tailor_count} resume{u.tailor_count !== 1 ? 's' : ''}</span>
-                        {u.has_used_extension && <span className="ml-1 text-blue-500">· ext</span>}
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex flex-wrap gap-1">
-                          {u.sent_notifications.map(t => (
-                            <span key={t} className="text-[10px] bg-zinc-800 text-zinc-500 px-1.5 py-0.5 rounded">{t.replace(/_/g, ' ')}</span>
-                          ))}
-                          {u.sent_notifications.length === 0 && <span className="text-zinc-700 text-xs">—</span>}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex flex-wrap gap-1 items-center">
-                          {u.eligible.map(t => (
-                            <span
-                              key={t}
-                              className={`text-[10px] px-1.5 py-0.5 rounded ${t === notificationType ? 'bg-blue-900/50 text-blue-400 ring-1 ring-blue-700' : 'bg-zinc-800/50 text-zinc-500'}`}
-                            >
-                              {t.replace(/_/g, ' ')}
-                            </span>
-                          ))}
-                          {u.eligible.length === 0 && <span className="text-zinc-700 text-xs">none</span>}
-                        </div>
-                      </td>
-                    </tr>
-                  </>
-                );
-              })}
+              {users.map((u, i) => (
+                <tr
+                  key={u.id}
+                  className={`border-b border-zinc-800/50 hover:bg-zinc-800/30 cursor-pointer transition-colors ${selectedIds.has(u.id) ? 'bg-blue-950/20' : ''}`}
+                  onClick={() => toggleUser(u.id)}
+                >
+                  <td className="px-4 py-3" onClick={e => e.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(u.id)}
+                      onChange={() => toggleUser(u.id)}
+                      className="accent-blue-500"
+                    />
+                  </td>
+                  <td className="px-4 py-3">
+                    <p className="text-zinc-200">{u.email}</p>
+                    {u.full_name && <p className="text-zinc-600 text-xs">{u.full_name}</p>}
+                  </td>
+                  <td className="px-4 py-3 text-zinc-500 text-xs">{daysSince(u.created_at)}</td>
+                  <td className="px-4 py-3 text-zinc-400 text-xs">
+                    <span>{u.doc_count} doc{u.doc_count !== 1 ? 's' : ''}</span>
+                    <span className="mx-1 text-zinc-700">·</span>
+                    <span>{u.tailor_count} resume{u.tailor_count !== 1 ? 's' : ''}</span>
+                    {u.has_used_extension && <span className="ml-1 text-blue-500">· ext</span>}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {u.sent_notifications.map(t => (
+                        <span key={t} className="text-[10px] bg-zinc-800 text-zinc-500 px-1.5 py-0.5 rounded">
+                          {t.replace(/_/g, ' ')}
+                        </span>
+                      ))}
+                      {u.sent_notifications.length === 0 && <span className="text-zinc-700 text-xs">—</span>}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {u.eligible.map(t => (
+                        <span
+                          key={t}
+                          className={`text-[10px] px-1.5 py-0.5 rounded ${t === notificationType ? 'bg-blue-900/50 text-blue-400 ring-1 ring-blue-700' : 'bg-zinc-800/50 text-zinc-500'}`}
+                        >
+                          {t.replace(/_/g, ' ')}
+                        </span>
+                      ))}
+                      {u.eligible.length === 0 && <span className="text-zinc-700 text-xs">none</span>}
+                    </div>
+                  </td>
+                </tr>
+              ))}
             </tbody>
           </table>
           <div className="px-4 py-2 border-t border-zinc-800 text-xs text-zinc-600">
@@ -337,6 +541,95 @@ export default function NotificationsAdminPage() {
         </div>
       ) : (
         <p className="text-zinc-600 text-sm">No users loaded.</p>
+      )}
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+type Tab = 'send' | 'scheduled' | 'history';
+
+export default function NotificationsAdminPage() {
+  const { secret } = useAdminContext();
+  const [activeTab, setActiveTab] = useState<Tab>('scheduled');
+  const [users, setUsers] = useState<UserRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchUsers = useCallback(async () => {
+    if (!secret) return;
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/admin/send-notification', { headers: { 'x-admin-secret': secret } });
+      if (!res.ok) { setError('Wrong secret or server error'); return; }
+      const data = await res.json();
+      setUsers(data.users);
+    } catch {
+      setError('Failed to fetch users');
+    }
+    setLoading(false);
+  }, [secret]);
+
+  useEffect(() => { fetchUsers(); }, [fetchUsers]);
+
+  const totalScheduled = users.reduce((sum, u) => sum + u.eligible.length, 0);
+
+  const TABS: { id: Tab; label: string; icon: React.ElementType; badge?: number }[] = [
+    { id: 'scheduled', label: 'Scheduled', icon: Clock, badge: totalScheduled },
+    { id: 'history', label: 'Sent history', icon: History },
+    { id: 'send', label: 'Send manually', icon: Send },
+  ];
+
+  return (
+    <div className="space-y-6 max-w-5xl">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-zinc-100">Notifications</h1>
+        <button
+          onClick={fetchUsers}
+          disabled={loading}
+          className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors flex items-center gap-1"
+        >
+          {loading && <Loader2 className="w-3 h-3 animate-spin" />}
+          Refresh
+        </button>
+      </div>
+
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+
+      {/* Tabs */}
+      <div className="flex border-b border-zinc-800">
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors border-b-2 ${
+              activeTab === tab.id
+                ? 'border-zinc-400 text-zinc-200'
+                : 'border-transparent text-zinc-500 hover:text-zinc-300'
+            }`}
+          >
+            <tab.icon className="w-4 h-4" />
+            {tab.label}
+            {tab.badge != null && tab.badge > 0 && (
+              <span className="bg-blue-600 text-white text-[10px] px-1.5 py-0.5 rounded-full font-medium">
+                {tab.badge}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'scheduled' && (
+        <ScheduledTab users={users} loading={loading} />
+      )}
+      {activeTab === 'history' && (
+        <HistoryTab secret={secret} />
+      )}
+      {activeTab === 'send' && (
+        <SendTab secret={secret} users={users} loading={loading} onRefresh={fetchUsers} />
       )}
     </div>
   );

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,41 +1,498 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useAdminContext } from './AdminContext';
-import { Users, TrendingUp, Crown, Mail, CheckCircle, XCircle, Loader2, Send } from 'lucide-react';
+import {
+  Users, TrendingUp, Crown, Mail, CheckCircle, XCircle, Loader2, Send,
+  ChevronRight, X, ArrowLeft, ExternalLink, FileText, Briefcase, Activity,
+  MapPin, Linkedin,
+} from 'lucide-react';
+
+// ── Types ────────────────────────────────────────────────────────────────────
 
 interface AdminStats {
   totalUsers: number;
   newUsers7d: number;
   newUsers30d: number;
   subscriptions: { free: number; pro: number; canceled: number };
-  recentSignups: { id: string; email: string; full_name: string | null; created_at: string; subscription_status: string }[];
+  recentSignups: UserRow[];
   resendConfigured: boolean;
   lastNotificationSentAt: string | null;
 }
 
-function StatCard({ label, value, sub, icon: Icon, color = 'text-zinc-400' }: {
-  label: string; value: number | string; sub?: string; icon: React.ElementType; color?: string;
+interface UserRow {
+  id: string;
+  email: string;
+  full_name: string | null;
+  created_at: string;
+  subscription_status: string | null;
+  tailored_resume_count?: number;
+}
+
+interface ResumeDoc {
+  id: string;
+  title: string;
+  item_type: string;
+  is_default: boolean;
+  created_at: string;
+}
+
+interface AppItem {
+  id: string;
+  company: string;
+  job_title: string;
+  created_at: string;
+}
+
+interface LogEntry {
+  id: string;
+  route: string;
+  method: string;
+  status_code: number | null;
+  request_body: Record<string, unknown> | null;
+  response_summary: Record<string, unknown> | null;
+  error: string | null;
+  duration_ms: number | null;
+  created_at: string;
+}
+
+interface UserDetail {
+  user: {
+    id: string;
+    email: string;
+    full_name: string | null;
+    subscription_status: string | null;
+    subscription_period_end: string | null;
+    created_at: string;
+    tailored_resume_count: number;
+    stripe_customer_id: string | null;
+  };
+  profile: {
+    full_name: string | null;
+    email: string | null;
+    location: string | null;
+    linkedin_url: string | null;
+  } | null;
+  resumes: ResumeDoc[];
+  applications: { total: number; recent: AppItem[] };
+  logs: LogEntry[];
+}
+
+type PanelSegment = 'all' | 'new7d' | 'new30d' | 'pro' | 'free' | 'canceled';
+
+const SEGMENT_LABELS: Record<PanelSegment, string> = {
+  all: 'All users',
+  new7d: 'New this week',
+  new30d: 'New this month',
+  pro: 'Pro subscribers',
+  free: 'Free users',
+  canceled: 'Canceled',
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function timeAgo(dateStr: string) {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const h = Math.floor(diff / 3600000);
+  if (h < 1) return 'just now';
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+function planBadge(status: string | null) {
+  if (status === 'pro') return 'bg-amber-900/40 text-amber-400';
+  if (status === 'canceled') return 'bg-red-900/30 text-red-400';
+  return 'bg-zinc-800 text-zinc-500';
+}
+
+function statusBadge(code: number | null) {
+  if (!code) return 'bg-zinc-800 text-zinc-400';
+  if (code < 300) return 'bg-emerald-900/40 text-emerald-400';
+  if (code < 400) return 'bg-blue-900/40 text-blue-400';
+  if (code < 500) return 'bg-amber-900/40 text-amber-400';
+  return 'bg-red-900/40 text-red-400';
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function StatCard({
+  label, value, sub, icon: Icon, color = 'text-zinc-400', onClick,
+}: {
+  label: string; value: number | string; sub?: string;
+  icon: React.ElementType; color?: string; onClick?: () => void;
 }) {
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
+    <button
+      onClick={onClick}
+      className={`bg-zinc-900 border border-zinc-800 rounded-lg p-5 text-left w-full transition-colors ${
+        onClick ? 'hover:border-zinc-600 hover:bg-zinc-800/60 cursor-pointer' : 'cursor-default'
+      }`}
+    >
       <div className="flex items-start justify-between mb-3">
         <p className="text-xs text-zinc-500 uppercase tracking-wider font-medium">{label}</p>
         <Icon className={`w-4 h-4 ${color}`} />
       </div>
       <p className="text-2xl font-semibold text-zinc-100">{value}</p>
       {sub && <p className="text-xs text-zinc-600 mt-1">{sub}</p>}
+      {onClick && (
+        <p className="text-xs text-zinc-600 mt-2 flex items-center gap-1">
+          View users <ChevronRight className="w-3 h-3" />
+        </p>
+      )}
+    </button>
+  );
+}
+
+// ── User Detail Panel ─────────────────────────────────────────────────────────
+
+function UserDetailPanel({
+  userId, secret, onBack,
+}: { userId: string; secret: string; onBack: () => void }) {
+  const [detail, setDetail] = useState<UserDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<'overview' | 'docs' | 'resumes' | 'logs'>('overview');
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/admin/users/${userId}`, { headers: { 'x-admin-secret': secret } })
+      .then(r => r.json())
+      .then(setDetail)
+      .finally(() => setLoading(false));
+  }, [userId, secret]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-40">
+        <Loader2 className="w-5 h-5 animate-spin text-zinc-600" />
+      </div>
+    );
+  }
+  if (!detail) return <p className="text-red-400 text-sm p-4">Failed to load user.</p>;
+
+  const { user, profile, resumes, applications, logs } = detail;
+
+  const TABS = [
+    { id: 'overview', label: 'Account' },
+    { id: 'docs', label: `Docs (${resumes.length})` },
+    { id: 'resumes', label: `Resumes (${applications.total})` },
+    { id: 'logs', label: `API Logs (${logs.length})` },
+  ] as const;
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-3 p-4 border-b border-zinc-800 shrink-0">
+        <button onClick={onBack} className="text-zinc-500 hover:text-zinc-300 transition-colors">
+          <ArrowLeft className="w-4 h-4" />
+        </button>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-zinc-200 truncate">
+            {user.full_name || user.email}
+          </p>
+          {user.full_name && (
+            <p className="text-xs text-zinc-500 truncate">{user.email}</p>
+          )}
+        </div>
+        <span className={`text-xs px-1.5 py-0.5 rounded shrink-0 ${planBadge(user.subscription_status)}`}>
+          {user.subscription_status ?? 'free'}
+        </span>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-zinc-800 shrink-0">
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`px-3 py-2.5 text-xs font-medium transition-colors border-b-2 ${
+              activeTab === tab.id
+                ? 'border-zinc-400 text-zinc-200'
+                : 'border-transparent text-zinc-500 hover:text-zinc-300'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {activeTab === 'overview' && (
+          <>
+            <Section title="Account info">
+              <Row label="User ID" value={<code className="text-xs text-zinc-400 font-mono break-all">{user.id}</code>} />
+              <Row label="Email" value={user.email} />
+              <Row label="Name" value={user.full_name ?? '—'} />
+              <Row label="Joined" value={new Date(user.created_at).toLocaleString()} />
+              <Row label="Plan" value={user.subscription_status ?? 'free'} />
+              <Row label="Resumes generated" value={String(user.tailored_resume_count)} />
+              {user.stripe_customer_id && (
+                <Row
+                  label="Stripe customer"
+                  value={
+                    <a
+                      href={`https://dashboard.stripe.com/customers/${user.stripe_customer_id}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-400 hover:underline flex items-center gap-1 text-xs"
+                    >
+                      {user.stripe_customer_id} <ExternalLink className="w-3 h-3" />
+                    </a>
+                  }
+                />
+              )}
+              {user.subscription_period_end && (
+                <Row label="Period ends" value={new Date(user.subscription_period_end).toLocaleDateString()} />
+              )}
+            </Section>
+
+            {profile && (
+              <Section title="Contact info">
+                {profile.full_name && <Row label="Name" value={profile.full_name} />}
+                {profile.email && <Row label="Email" value={profile.email} />}
+                {profile.location && (
+                  <Row label="Location" value={
+                    <span className="flex items-center gap-1"><MapPin className="w-3 h-3" />{profile.location}</span>
+                  } />
+                )}
+                {profile.linkedin_url && (
+                  <Row label="LinkedIn" value={
+                    <a href={profile.linkedin_url} target="_blank" rel="noreferrer"
+                      className="text-blue-400 hover:underline flex items-center gap-1 text-xs">
+                      <Linkedin className="w-3 h-3" />
+                      View profile <ExternalLink className="w-3 h-3" />
+                    </a>
+                  } />
+                )}
+              </Section>
+            )}
+          </>
+        )}
+
+        {activeTab === 'docs' && (
+          <Section title="Experience library">
+            {resumes.length === 0 ? (
+              <p className="text-zinc-600 text-xs py-2">No documents uploaded.</p>
+            ) : (
+              <div className="space-y-2">
+                {resumes.map(doc => (
+                  <div key={doc.id} className="flex items-start justify-between gap-2 py-2 border-b border-zinc-800/50 last:border-0">
+                    <div className="flex items-start gap-2 min-w-0">
+                      <FileText className="w-3.5 h-3.5 text-zinc-500 mt-0.5 shrink-0" />
+                      <div className="min-w-0">
+                        <p className="text-xs text-zinc-300 truncate">{doc.title}</p>
+                        <p className="text-xs text-zinc-600">{doc.item_type.replace('_', ' ')}{doc.is_default ? ' · default' : ''}</p>
+                      </div>
+                    </div>
+                    <p className="text-xs text-zinc-600 shrink-0">{timeAgo(doc.created_at)}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Section>
+        )}
+
+        {activeTab === 'resumes' && (
+          <Section title={`AI resumes (${applications.total} total)`}>
+            {applications.recent.length === 0 ? (
+              <p className="text-zinc-600 text-xs py-2">No resumes generated yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {applications.recent.map(app => (
+                  <div key={app.id} className="flex items-start justify-between gap-2 py-2 border-b border-zinc-800/50 last:border-0">
+                    <div className="flex items-start gap-2 min-w-0">
+                      <Briefcase className="w-3.5 h-3.5 text-zinc-500 mt-0.5 shrink-0" />
+                      <div className="min-w-0">
+                        <p className="text-xs text-zinc-300 truncate">{app.job_title}</p>
+                        <p className="text-xs text-zinc-600 truncate">{app.company}</p>
+                      </div>
+                    </div>
+                    <p className="text-xs text-zinc-600 shrink-0">{timeAgo(app.created_at)}</p>
+                  </div>
+                ))}
+                {applications.total > applications.recent.length && (
+                  <p className="text-xs text-zinc-600 pt-1">
+                    + {applications.total - applications.recent.length} more
+                  </p>
+                )}
+              </div>
+            )}
+          </Section>
+        )}
+
+        {activeTab === 'logs' && (
+          <Section title="Recent API calls">
+            {logs.length === 0 ? (
+              <p className="text-zinc-600 text-xs py-2">No logged API calls.</p>
+            ) : (
+              <div className="space-y-1.5">
+                {logs.map(log => (
+                  <LogRow key={log.id} log={log} />
+                ))}
+              </div>
+            )}
+          </Section>
+        )}
+      </div>
     </div>
   );
 }
 
-function timeAgo(dateStr: string) {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const h = Math.floor(diff / 3600000);
-  if (h < 24) return h === 0 ? 'just now' : `${h}h ago`;
-  const d = Math.floor(h / 24);
-  return `${d}d ago`;
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-2">{title}</p>
+      <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-3">{children}</div>
+    </div>
+  );
 }
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-3 py-1.5 text-xs border-b border-zinc-800/50 last:border-0">
+      <span className="text-zinc-500 shrink-0 w-28">{label}</span>
+      <span className="text-zinc-300 text-right break-all">{value}</span>
+    </div>
+  );
+}
+
+function LogRow({ log }: { log: LogEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  const routeShort = log.route.replace('/api/', '');
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded text-xs overflow-hidden">
+      <button
+        onClick={() => setExpanded(v => !v)}
+        className="w-full flex items-center gap-2 px-3 py-2 hover:bg-zinc-800/40 transition-colors text-left"
+      >
+        <span className={`shrink-0 px-1.5 py-0.5 rounded text-[10px] font-mono ${statusBadge(log.status_code)}`}>
+          {log.status_code ?? '?'}
+        </span>
+        <span className="text-zinc-300 font-mono flex-1 truncate">{routeShort}</span>
+        {log.duration_ms != null && (
+          <span className="text-zinc-600 shrink-0">{log.duration_ms}ms</span>
+        )}
+        <span className="text-zinc-600 shrink-0">{timeAgo(log.created_at)}</span>
+      </button>
+      {expanded && (
+        <div className="border-t border-zinc-800 px-3 py-2 space-y-2">
+          {log.error && (
+            <div>
+              <p className="text-red-400 font-medium mb-0.5">Error</p>
+              <pre className="text-red-300 text-[10px] whitespace-pre-wrap break-all">{log.error}</pre>
+            </div>
+          )}
+          {log.request_body && (
+            <div>
+              <p className="text-zinc-500 font-medium mb-0.5">Request</p>
+              <pre className="text-zinc-400 text-[10px] whitespace-pre-wrap break-all">
+                {JSON.stringify(log.request_body, null, 2)}
+              </pre>
+            </div>
+          )}
+          {log.response_summary && (
+            <div>
+              <p className="text-zinc-500 font-medium mb-0.5">Response summary</p>
+              <pre className="text-zinc-400 text-[10px] whitespace-pre-wrap break-all">
+                {JSON.stringify(log.response_summary, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Users list panel ──────────────────────────────────────────────────────────
+
+function UsersListPanel({
+  segment, secret, onSelectUser,
+}: { segment: PanelSegment; secret: string; onSelectUser: (id: string) => void }) {
+  const [users, setUsers] = useState<UserRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback((p: number) => {
+    setLoading(true);
+    fetch(`/api/admin/users?segment=${segment}&page=${p}`, { headers: { 'x-admin-secret': secret } })
+      .then(r => r.json())
+      .then(data => { setUsers(data.users ?? []); setTotal(data.total ?? 0); setPage(p); })
+      .finally(() => setLoading(false));
+  }, [segment, secret]);
+
+  useEffect(() => { load(1); }, [load]);
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="px-4 py-3 border-b border-zinc-800 shrink-0">
+        <p className="text-sm font-medium text-zinc-300">{SEGMENT_LABELS[segment]}</p>
+        <p className="text-xs text-zinc-600">{total} users</p>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center h-24">
+          <Loader2 className="w-4 h-4 animate-spin text-zinc-600" />
+        </div>
+      ) : users.length === 0 ? (
+        <p className="text-zinc-600 text-sm p-4">No users found.</p>
+      ) : (
+        <>
+          <div className="flex-1 overflow-y-auto">
+            {users.map((u, i) => (
+              <button
+                key={u.id}
+                onClick={() => onSelectUser(u.id)}
+                className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-zinc-800/40 transition-colors ${
+                  i < users.length - 1 ? 'border-b border-zinc-800/50' : ''
+                }`}
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-zinc-200 truncate">{u.full_name || u.email}</p>
+                  {u.full_name && <p className="text-xs text-zinc-600 truncate">{u.email}</p>}
+                  <p className="text-xs text-zinc-600">{timeAgo(u.created_at)}</p>
+                </div>
+                <div className="flex flex-col items-end gap-1 shrink-0">
+                  <span className={`text-xs px-1.5 py-0.5 rounded ${planBadge(u.subscription_status)}`}>
+                    {u.subscription_status ?? 'free'}
+                  </span>
+                  {u.tailored_resume_count != null && (
+                    <span className="text-xs text-zinc-600">{u.tailored_resume_count} resumes</span>
+                  )}
+                </div>
+                <ChevronRight className="w-3.5 h-3.5 text-zinc-600 shrink-0" />
+              </button>
+            ))}
+          </div>
+          {total > 50 && (
+            <div className="flex items-center justify-between px-4 py-3 border-t border-zinc-800 shrink-0 text-xs">
+              <button
+                disabled={page === 1}
+                onClick={() => load(page - 1)}
+                className="text-zinc-500 hover:text-zinc-300 disabled:opacity-30"
+              >
+                ← Prev
+              </button>
+              <span className="text-zinc-600">Page {page} of {Math.ceil(total / 50)}</span>
+              <button
+                disabled={page * 50 >= total}
+                onClick={() => load(page + 1)}
+                className="text-zinc-500 hover:text-zinc-300 disabled:opacity-30"
+              >
+                Next →
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function AdminOverviewPage() {
   const { secret } = useAdminContext();
@@ -43,6 +500,16 @@ export default function AdminOverviewPage() {
   const [loading, setLoading] = useState(true);
   const [testSending, setTestSending] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+
+  // Panel state
+  const [panelSegment, setPanelSegment] = useState<PanelSegment | null>(null);
+  const [panelUserId, setPanelUserId] = useState<string | null>(null);
+
+  const openSegment = (seg: PanelSegment) => {
+    setPanelUserId(null);
+    setPanelSegment(seg);
+  };
+  const closePanel = () => { setPanelSegment(null); setPanelUserId(null); };
 
   useEffect(() => {
     if (!secret) return;
@@ -80,105 +547,146 @@ export default function AdminOverviewPage() {
       </div>
     );
   }
-
   if (!stats) return <p className="text-red-400 text-sm">Failed to load stats.</p>;
 
   return (
-    <div className="space-y-8 max-w-4xl">
-      <h1 className="text-lg font-semibold text-zinc-100">Overview</h1>
+    <div className="flex gap-6 min-h-0">
+      {/* Main content */}
+      <div className={`space-y-8 transition-all duration-200 ${panelSegment ? 'max-w-xl' : 'max-w-4xl'} flex-1 min-w-0`}>
+        <h1 className="text-lg font-semibold text-zinc-100">Overview</h1>
 
-      {/* Stats grid */}
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-        <StatCard label="Total users" value={stats.totalUsers} icon={Users} color="text-blue-400" />
-        <StatCard label="New (7d)" value={stats.newUsers7d} sub={`${stats.newUsers30d} in last 30d`} icon={TrendingUp} color="text-green-400" />
-        <StatCard label="Pro subscribers" value={stats.subscriptions.pro} sub={`${stats.subscriptions.canceled} canceled`} icon={Crown} color="text-amber-400" />
-        <StatCard
-          label="Free users"
-          value={stats.subscriptions.free}
-          sub={`${Math.round((stats.subscriptions.free / Math.max(stats.totalUsers, 1)) * 100)}% of total`}
-          icon={Users}
-        />
-      </div>
-
-      {/* Email health */}
-      <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-sm font-medium text-zinc-300 flex items-center gap-2">
-            <Mail className="w-4 h-4 text-zinc-500" />
-            Email health
-          </h2>
-          <button
-            onClick={sendTestEmail}
-            disabled={testSending || !stats.resendConfigured}
-            className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded bg-zinc-700 hover:bg-zinc-600 disabled:opacity-40 transition-colors"
-          >
-            {testSending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
-            Send test email
-          </button>
+        {/* Stats grid */}
+        <div className="grid grid-cols-2 gap-4">
+          <StatCard
+            label="Total users" value={stats.totalUsers}
+            icon={Users} color="text-blue-400"
+            onClick={() => openSegment('all')}
+          />
+          <StatCard
+            label="New (7d)" value={stats.newUsers7d}
+            sub={`${stats.newUsers30d} in last 30d`}
+            icon={TrendingUp} color="text-green-400"
+            onClick={() => openSegment('new7d')}
+          />
+          <StatCard
+            label="Pro subscribers" value={stats.subscriptions.pro}
+            sub={`${stats.subscriptions.canceled} canceled`}
+            icon={Crown} color="text-amber-400"
+            onClick={() => openSegment('pro')}
+          />
+          <StatCard
+            label="Free users" value={stats.subscriptions.free}
+            sub={`${Math.round((stats.subscriptions.free / Math.max(stats.totalUsers, 1)) * 100)}% of total`}
+            icon={Users}
+            onClick={() => openSegment('free')}
+          />
         </div>
 
-        <div className="space-y-2 text-sm">
-          <div className="flex items-center gap-2">
-            {stats.resendConfigured
-              ? <CheckCircle className="w-4 h-4 text-green-400 shrink-0" />
-              : <XCircle className="w-4 h-4 text-red-400 shrink-0" />
-            }
-            <span className={stats.resendConfigured ? 'text-zinc-300' : 'text-red-400'}>
-              Resend API key {stats.resendConfigured ? 'configured' : 'not configured — emails will not send'}
-            </span>
+        {/* Email health */}
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-medium text-zinc-300 flex items-center gap-2">
+              <Mail className="w-4 h-4 text-zinc-500" />
+              Email health
+            </h2>
+            <button
+              onClick={sendTestEmail}
+              disabled={testSending || !stats.resendConfigured}
+              className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded bg-zinc-700 hover:bg-zinc-600 disabled:opacity-40 transition-colors"
+            >
+              {testSending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
+              Send test email
+            </button>
           </div>
-          <div className="flex items-center gap-2 text-zinc-500 text-xs pl-6">
-            Last notification sent: {stats.lastNotificationSentAt ? timeAgo(stats.lastNotificationSentAt) : 'never'}
-          </div>
-          {testResult && (
-            <div className={`flex items-center gap-2 mt-2 pl-6 text-xs ${testResult.ok ? 'text-green-400' : 'text-red-400'}`}>
-              {testResult.ok ? <CheckCircle className="w-3.5 h-3.5 shrink-0" /> : <XCircle className="w-3.5 h-3.5 shrink-0" />}
-              {testResult.message}
+          <div className="space-y-2 text-sm">
+            <div className="flex items-center gap-2">
+              {stats.resendConfigured
+                ? <CheckCircle className="w-4 h-4 text-green-400 shrink-0" />
+                : <XCircle className="w-4 h-4 text-red-400 shrink-0" />}
+              <span className={stats.resendConfigured ? 'text-zinc-300' : 'text-red-400'}>
+                Resend API key {stats.resendConfigured ? 'configured' : 'not configured — emails will not send'}
+              </span>
             </div>
+            <div className="flex items-center gap-2 text-zinc-500 text-xs pl-6">
+              Last notification sent: {stats.lastNotificationSentAt ? timeAgo(stats.lastNotificationSentAt) : 'never'}
+            </div>
+            {testResult && (
+              <div className={`flex items-center gap-2 mt-2 pl-6 text-xs ${testResult.ok ? 'text-green-400' : 'text-red-400'}`}>
+                {testResult.ok ? <CheckCircle className="w-3.5 h-3.5 shrink-0" /> : <XCircle className="w-3.5 h-3.5 shrink-0" />}
+                {testResult.message}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Recent signups */}
+        <div>
+          <h2 className="text-sm font-medium text-zinc-400 mb-3">Recent signups</h2>
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800 text-left">
+                  <th className="px-4 py-2.5 text-xs text-zinc-500 font-medium">User</th>
+                  <th className="px-4 py-2.5 text-xs text-zinc-500 font-medium">Plan</th>
+                  <th className="px-4 py-2.5 text-xs text-zinc-500 font-medium">Joined</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.recentSignups.map((u, i) => (
+                  <tr
+                    key={u.id}
+                    onClick={() => { setPanelSegment('all'); setPanelUserId(u.id); }}
+                    className={`${i < stats.recentSignups.length - 1 ? 'border-b border-zinc-800/50' : ''} hover:bg-zinc-800/30 transition-colors cursor-pointer`}
+                  >
+                    <td className="px-4 py-3">
+                      <p className="text-zinc-200">{u.full_name || u.email}</p>
+                      {u.full_name && <p className="text-zinc-600 text-xs">{u.email}</p>}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`text-xs px-1.5 py-0.5 rounded ${planBadge(u.subscription_status)}`}>
+                        {u.subscription_status ?? 'free'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-zinc-500 text-xs flex items-center gap-1">
+                      {timeAgo(u.created_at)} <Activity className="w-3 h-3" />
+                    </td>
+                  </tr>
+                ))}
+                {stats.recentSignups.length === 0 && (
+                  <tr><td colSpan={3} className="px-4 py-6 text-center text-zinc-600 text-sm">No users yet.</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      {/* Side panel */}
+      {panelSegment && (
+        <div className="w-96 shrink-0 bg-zinc-900 border border-zinc-800 rounded-lg flex flex-col overflow-hidden self-start sticky top-0 max-h-[calc(100vh-4rem)]">
+          {/* Panel header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800 shrink-0">
+            <p className="text-xs text-zinc-500 uppercase tracking-wider font-medium">Users</p>
+            <button onClick={closePanel} className="text-zinc-600 hover:text-zinc-300 transition-colors">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          {panelUserId ? (
+            <UserDetailPanel
+              userId={panelUserId}
+              secret={secret}
+              onBack={() => setPanelUserId(null)}
+            />
+          ) : (
+            <UsersListPanel
+              segment={panelSegment}
+              secret={secret}
+              onSelectUser={id => setPanelUserId(id)}
+            />
           )}
         </div>
-      </div>
-
-      {/* Recent signups */}
-      <div>
-        <h2 className="text-sm font-medium text-zinc-400 mb-3">Recent signups</h2>
-        <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-zinc-800 text-left">
-                <th className="px-4 py-2.5 text-xs text-zinc-500 font-medium">User</th>
-                <th className="px-4 py-2.5 text-xs text-zinc-500 font-medium">Plan</th>
-                <th className="px-4 py-2.5 text-xs text-zinc-500 font-medium">Joined</th>
-              </tr>
-            </thead>
-            <tbody>
-              {stats.recentSignups.map((u, i) => (
-                <tr key={u.id} className={`${i < stats.recentSignups.length - 1 ? 'border-b border-zinc-800/50' : ''} hover:bg-zinc-800/30 transition-colors`}>
-                  <td className="px-4 py-3">
-                    <p className="text-zinc-200">{u.full_name || u.email}</p>
-                    {u.full_name && <p className="text-zinc-600 text-xs">{u.email}</p>}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={`text-xs px-1.5 py-0.5 rounded ${
-                      u.subscription_status === 'pro'
-                        ? 'bg-amber-900/40 text-amber-400'
-                        : u.subscription_status === 'canceled'
-                        ? 'bg-red-900/30 text-red-400'
-                        : 'bg-zinc-800 text-zinc-500'
-                    }`}>
-                      {u.subscription_status ?? 'free'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-zinc-500 text-xs">{timeAgo(u.created_at)}</td>
-                </tr>
-              ))}
-              {stats.recentSignups.length === 0 && (
-                <tr><td colSpan={3} className="px-4 py-6 text-center text-zinc-600 text-sm">No users yet.</td></tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/app/api/admin/email-history/route.ts
+++ b/app/api/admin/email-history/route.ts
@@ -1,0 +1,50 @@
+export const runtime = 'nodejs';
+
+import { NextRequest } from 'next/server';
+import { supabaseServer } from '@/lib/supabase';
+
+export async function GET(req: NextRequest) {
+  const secret = process.env.ADMIN_SECRET;
+  if (!secret || req.headers.get('x-admin-secret') !== secret) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+  const type = searchParams.get('type') ?? '';
+  const limit = 50;
+  const offset = (page - 1) * limit;
+
+  const supabase = supabaseServer();
+
+  let query = supabase
+    .from('user_notifications')
+    .select('id, user_id, notification_type, sent_at', { count: 'exact' })
+    .order('sent_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (type) query = query.eq('notification_type', type as 'setup_experience' | 'first_tailor' | 'add_more_experience' | 'job_hunt_checkin' | 'try_extension');
+
+  const { data: rows, count, error } = await query;
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  // Enrich with user info
+  const userIds = Array.from(new Set((rows ?? []).map(r => r.user_id)));
+  let usersMap: Record<string, { email: string; full_name: string | null }> = {};
+  if (userIds.length > 0) {
+    const { data: users } = await supabase
+      .from('users')
+      .select('id, email, full_name')
+      .in('id', userIds);
+    for (const u of users ?? []) {
+      usersMap[u.id] = { email: u.email, full_name: u.full_name };
+    }
+  }
+
+  const enriched = (rows ?? []).map(r => ({
+    ...r,
+    user: usersMap[r.user_id] ?? null,
+  }));
+
+  return Response.json({ history: enriched, total: count ?? 0, page, limit });
+}

--- a/app/api/admin/logs/route.ts
+++ b/app/api/admin/logs/route.ts
@@ -1,0 +1,55 @@
+export const runtime = 'nodejs';
+
+import { NextRequest } from 'next/server';
+import { supabaseServer } from '@/lib/supabase';
+
+export async function GET(req: NextRequest) {
+  const secret = process.env.ADMIN_SECRET;
+  if (!secret || req.headers.get('x-admin-secret') !== secret) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get('userId') ?? '';
+  const route = searchParams.get('route') ?? '';
+  const hasError = searchParams.get('hasError');
+  const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+  const limit = 50;
+  const offset = (page - 1) * limit;
+
+  const supabase = supabaseServer();
+
+  let query = supabase
+    .from('api_logs')
+    .select('*', { count: 'exact' })
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (userId) query = query.eq('user_id', userId);
+  if (route) query = query.ilike('route', `%${route}%`);
+  if (hasError === 'true') query = query.not('error', 'is', null);
+  if (hasError === 'false') query = query.is('error', null);
+
+  const { data: logs, count, error } = await query;
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  // Enrich logs with user info
+  const userIds = Array.from(new Set((logs ?? []).map(l => l.user_id).filter(Boolean))) as string[];
+  let usersMap: Record<string, { email: string; full_name: string | null }> = {};
+  if (userIds.length > 0) {
+    const { data: users } = await supabase
+      .from('users')
+      .select('id, email, full_name')
+      .in('id', userIds);
+    for (const u of users ?? []) {
+      usersMap[u.id] = { email: u.email, full_name: u.full_name };
+    }
+  }
+
+  const enriched = (logs ?? []).map(log => ({
+    ...log,
+    user: log.user_id ? (usersMap[log.user_id] ?? null) : null,
+  }));
+
+  return Response.json({ logs: enriched, total: count ?? 0, page, limit });
+}

--- a/app/api/admin/trigger-notifications/route.ts
+++ b/app/api/admin/trigger-notifications/route.ts
@@ -1,0 +1,35 @@
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+import { NextRequest } from 'next/server';
+import { fetchAllUserStats, getEligibleNotifications, sendNotification } from '@/lib/notifications';
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.ADMIN_SECRET;
+  if (!secret || req.headers.get('x-admin-secret') !== secret) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  if (!process.env.RESEND_API_KEY) {
+    return Response.json({ error: 'RESEND_API_KEY not configured' }, { status: 500 });
+  }
+
+  const users = await fetchAllUserStats();
+  const results: { userId: string; email: string; type: string; ok: boolean; error?: string }[] = [];
+
+  for (const user of users) {
+    const eligible = getEligibleNotifications(user);
+    for (const type of eligible) {
+      const result = await sendNotification(user.id, type, user.email, user.full_name ?? user.email);
+      results.push({ userId: user.id, email: user.email, type, ...result });
+    }
+  }
+
+  const sent = results.filter(r => r.ok).length;
+  const skipped = results.filter(r => !r.ok && r.error === 'already_sent').length;
+  const failed = results.filter(r => !r.ok && r.error !== 'already_sent').length;
+
+  console.log(`[admin/trigger-notifications] users=${users.length} sent=${sent} skipped=${skipped} failed=${failed}`);
+
+  return Response.json({ users: users.length, sent, skipped, failed, results });
+}

--- a/app/api/admin/users/[userId]/route.ts
+++ b/app/api/admin/users/[userId]/route.ts
@@ -1,0 +1,63 @@
+export const runtime = 'nodejs';
+
+import { NextRequest } from 'next/server';
+import { supabaseServer } from '@/lib/supabase';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const secret = process.env.ADMIN_SECRET;
+  if (!secret || req.headers.get('x-admin-secret') !== secret) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const { userId } = await params;
+  const supabase = supabaseServer();
+
+  const [userResult, profileResult, resumesResult, applicationsResult, logsResult] =
+    await Promise.all([
+      supabase
+        .from('users')
+        .select('id, email, full_name, subscription_status, subscription_period_end, created_at, tailored_resume_count, stripe_customer_id')
+        .eq('id', userId)
+        .single(),
+      supabase
+        .from('user_profiles')
+        .select('full_name, email, location, linkedin_url')
+        .eq('user_id', userId)
+        .maybeSingle(),
+      supabase
+        .from('resumes')
+        .select('id, title, item_type, is_default, created_at')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false }),
+      supabase
+        .from('applications')
+        .select('id, company, job_title, created_at', { count: 'exact' })
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(10),
+      supabase
+        .from('api_logs')
+        .select('id, route, method, status_code, request_body, response_summary, error, duration_ms, created_at')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(30),
+    ]);
+
+  if (!userResult.data) {
+    return Response.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  return Response.json({
+    user: userResult.data,
+    profile: profileResult.data ?? null,
+    resumes: resumesResult.data ?? [],
+    applications: {
+      total: applicationsResult.count ?? 0,
+      recent: applicationsResult.data ?? [],
+    },
+    logs: logsResult.data ?? [],
+  });
+}

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,51 @@
+export const runtime = 'nodejs';
+
+import { NextRequest } from 'next/server';
+import { supabaseServer } from '@/lib/supabase';
+
+export async function GET(req: NextRequest) {
+  const secret = process.env.ADMIN_SECRET;
+  if (!secret || req.headers.get('x-admin-secret') !== secret) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const segment = searchParams.get('segment') ?? 'all';
+  const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+  const limit = 50;
+  const offset = (page - 1) * limit;
+
+  const supabase = supabaseServer();
+  const now = new Date();
+  const d7ago = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const d30ago = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  let query = supabase
+    .from('users')
+    .select('id, email, full_name, subscription_status, created_at, tailored_resume_count', { count: 'exact' })
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  switch (segment) {
+    case 'new7d':
+      query = query.gte('created_at', d7ago);
+      break;
+    case 'new30d':
+      query = query.gte('created_at', d30ago);
+      break;
+    case 'pro':
+      query = query.eq('subscription_status', 'pro');
+      break;
+    case 'canceled':
+      query = query.eq('subscription_status', 'canceled');
+      break;
+    case 'free':
+      query = query.or('subscription_status.eq.free,subscription_status.is.null');
+      break;
+  }
+
+  const { data: users, count, error } = await query;
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json({ users: users ?? [], total: count ?? 0, page, limit });
+}

--- a/app/api/analyze-fit/route.ts
+++ b/app/api/analyze-fit/route.ts
@@ -4,8 +4,10 @@ import { Anthropic } from '@anthropic-ai/sdk';
 import { getModels } from '@/lib/models';
 import { parseStageJSON, buildContextBlock } from '@/lib/pipeline-utils';
 import { FitAnalysis } from '@/types/fit-analysis';
+import { logApiCall } from '@/lib/log-api';
 
 export async function POST(req: NextRequest) {
+  const startMs = Date.now();
   try {
     if (!process.env.ANTHROPIC_API_KEY) {
       return new Response('ANTHROPIC_API_KEY not set', { status: 500 });
@@ -74,10 +76,27 @@ Output valid JSON only, no markdown fences:
     const fitAnalysis = parseStageJSON<FitAnalysis>(text);
     console.log('[analyze-fit] Parsed successfully:', JSON.stringify(fitAnalysis).slice(0, 300));
 
+    logApiCall({
+      user_id: userId,
+      route: '/api/analyze-fit',
+      method: 'POST',
+      status_code: 200,
+      request_body: { company, jobTitle },
+      response_summary: { overallFit: fitAnalysis?.overallFit, roleType: fitAnalysis?.roleType },
+      duration_ms: Date.now() - startMs,
+    });
+
     return Response.json(fitAnalysis);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error('[analyze-fit] Failed:', message);
+    logApiCall({
+      route: '/api/analyze-fit',
+      method: 'POST',
+      status_code: 500,
+      error: message,
+      duration_ms: Date.now() - startMs,
+    });
     return new Response(message, { status: 500 });
   }
 }

--- a/app/api/billing/create-checkout/route.ts
+++ b/app/api/billing/create-checkout/route.ts
@@ -2,10 +2,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { stripe } from '@/lib/stripe';
 import { supabaseServer } from '@/lib/supabase';
+import { logApiCall } from '@/lib/log-api';
 
 export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
+  const startMs = Date.now();
   try {
     const { userId } = await auth();
     if (!userId) {
@@ -55,10 +57,27 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       metadata: { userId },
     });
 
+    logApiCall({
+      user_id: userId,
+      route: '/api/billing/create-checkout',
+      method: 'POST',
+      status_code: 200,
+      request_body: { plan },
+      response_summary: { hasUrl: !!session.url },
+      duration_ms: Date.now() - startMs,
+    });
+
     return NextResponse.json({ url: session.url });
   } catch (err) {
     console.error('[/api/billing/create-checkout]', err);
     const message = err instanceof Error ? err.message : 'Checkout failed';
+    logApiCall({
+      route: '/api/billing/create-checkout',
+      method: 'POST',
+      status_code: 500,
+      error: message,
+      duration_ms: Date.now() - startMs,
+    });
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/generate-documents/route.ts
+++ b/app/api/generate-documents/route.ts
@@ -7,10 +7,12 @@ import { getModels } from '@/lib/models';
 import { buildContextBlock, parseStageJSON } from '@/lib/pipeline-utils';
 import { supabaseServer } from '@/lib/supabase';
 import { FitAnalysis } from '@/types/fit-analysis';
+import { logApiCall } from '@/lib/log-api';
 
 export async function POST(req: NextRequest) {
   console.log('[generate-documents] Request received');
-  
+  const startMs = Date.now();
+
   try {
     // Check for ANTHROPIC_API_KEY at runtime
     if (!process.env.ANTHROPIC_API_KEY) {
@@ -47,6 +49,25 @@ export async function POST(req: NextRequest) {
     if (!company || !jobTitle || !jobDescription || !backgroundExperience) {
       return new Response('Missing required fields', { status: 400 });
     }
+
+    logApiCall({
+      user_id: userId,
+      route: '/api/generate-documents',
+      method: 'POST',
+      status_code: 200,
+      request_body: {
+        company,
+        jobTitle,
+        jobDescriptionLen: jobDescription?.length ?? 0,
+        backgroundLen: backgroundExperience?.length ?? 0,
+        additionalContextCount: additionalContext?.length ?? 0,
+        includeCoverLetter,
+        includeSummary,
+        hasJobUrl: !!jobUrl,
+        questionCount: questions?.length ?? 0,
+      },
+      duration_ms: Date.now() - startMs,
+    });
 
     // Fetch user subscription status + profile in parallel
     const supabase = supabaseServer();
@@ -360,7 +381,15 @@ Output valid JSON only, no markdown fences:
     });
 
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     console.error('API error:', error);
+    logApiCall({
+      route: '/api/generate-documents',
+      method: 'POST',
+      status_code: 500,
+      error: message,
+      duration_ms: Date.now() - startMs,
+    });
     return new Response('Internal server error', { status: 500 });
   }
 }

--- a/lib/log-api.ts
+++ b/lib/log-api.ts
@@ -1,0 +1,58 @@
+import { supabaseServer } from '@/lib/supabase';
+
+export interface ApiLogEntry {
+  user_id?: string | null;
+  route: string;
+  method?: string;
+  status_code: number;
+  request_body?: Record<string, unknown> | null;
+  response_summary?: Record<string, unknown> | null;
+  error?: string | null;
+  duration_ms?: number | null;
+}
+
+/** Truncate long string values so we don't store huge payloads in JSONB. */
+export function sanitizeBody(
+  body: Record<string, unknown>,
+  maxLen = 300
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (typeof v === 'string' && v.length > maxLen) {
+      out[k] = `[${v.length} chars]`;
+    } else if (Array.isArray(v)) {
+      out[k] = `[array(${v.length})]`;
+    } else if (v !== null && typeof v === 'object') {
+      out[k] = '[object]';
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Fire-and-forget API call logger. Never throws or blocks the response.
+ * Works in both Node and Edge runtimes.
+ */
+export function logApiCall(entry: ApiLogEntry): void {
+  try {
+    const supabase = supabaseServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    void Promise.resolve((supabase as any)
+      .from('api_logs')
+      .insert({
+        user_id: entry.user_id ?? null,
+        route: entry.route,
+        method: entry.method ?? 'POST',
+        status_code: entry.status_code,
+        request_body: entry.request_body ?? null,
+        response_summary: entry.response_summary ?? null,
+        error: entry.error ?? null,
+        duration_ms: entry.duration_ms ?? null,
+      })
+    ).then(() => {}).catch((err: unknown) => console.error('[logApiCall] insert failed:', err));
+  } catch (err) {
+    console.error('[logApiCall] setup failed:', err);
+  }
+}

--- a/supabase/migrations/017_api_logs.sql
+++ b/supabase/migrations/017_api_logs.sql
@@ -1,0 +1,21 @@
+-- Run in Supabase SQL editor → Dashboard → SQL Editor
+-- Stores API request/response logs for admin monitoring and debugging
+
+CREATE TABLE IF NOT EXISTS api_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT,                       -- NULL for unauthenticated requests
+  route TEXT NOT NULL,                -- e.g. /api/generate-documents
+  method TEXT NOT NULL DEFAULT 'POST',
+  status_code INTEGER,
+  request_body JSONB,                 -- sanitized (long strings truncated)
+  response_summary JSONB,             -- small summary, not full response
+  error TEXT,                         -- error message if status >= 400
+  duration_ms INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_api_logs_user_id ON api_logs(user_id);
+CREATE INDEX idx_api_logs_created_at ON api_logs(created_at DESC);
+CREATE INDEX idx_api_logs_route ON api_logs(route);
+CREATE INDEX idx_api_logs_status_code ON api_logs(status_code);
+CREATE INDEX idx_api_logs_error ON api_logs(error) WHERE error IS NOT NULL;

--- a/types/database.ts
+++ b/types/database.ts
@@ -9,6 +9,45 @@ export type Json =
 export interface Database {
   public: {
     Tables: {
+      api_logs: {
+        Row: {
+          id: string
+          user_id: string | null
+          route: string
+          method: string
+          status_code: number | null
+          request_body: Json | null
+          response_summary: Json | null
+          error: string | null
+          duration_ms: number | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          route: string
+          method?: string
+          status_code?: number | null
+          request_body?: Json | null
+          response_summary?: Json | null
+          error?: string | null
+          duration_ms?: number | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          route?: string
+          method?: string
+          status_code?: number | null
+          request_body?: Json | null
+          response_summary?: Json | null
+          error?: string | null
+          duration_ms?: number | null
+          created_at?: string
+        }
+        Relationships: []
+      }
       api_usage: {
         Row: {
           id: string


### PR DESCRIPTION
## Summary
- Stat cards in admin overview are now clickable — opens right-side panel showing users filtered by segment (all, new 7d/30d, pro, free, canceled)
- Each user has a 4-tab detail panel: Account info (Stripe link, contact), Docs, AI Resumes, API Logs
- New **API Logs** tab in admin sidebar with paginated log table, req/res body expansion, user name enrichment, route/error/user filters
- Notifications page redesigned with 3 tabs:
  - **Scheduled** — shows all users currently eligible for lifecycle emails, grouped by email type with pending counts
  - **Sent history** — complete paginated log of every email sent with timestamp
  - **Send manually** — existing manual send + new "Run now" button to trigger the cron immediately without waiting
- `api_logs` Supabase table (migration 017) tracks route, method, status, sanitized req/res, error, duration, user_id
- `logApiCall()` fire-and-forget helper instruments `/api/generate-documents`, `/api/analyze-fit`, `/api/billing/create-checkout`

## Why emails may not be sending automatically
The cron job is correctly configured and the NULL-unsubscribe bug is already fixed (PR #146). Most likely causes if you're still not seeing sends:
1. **`RESEND_API_KEY` not set in Vercel production env** — the admin Overview page now shows a red indicator if this is missing
2. **`NOTIFICATION_FROM_EMAIL` not set** — falls back to `Easy Apply AI <hello@easy-apply.ai>` but Resend may reject if that domain isn't verified; set it to your verified sending address
3. **Users already received those notifications** — use the new "Sent history" tab to confirm; use "Scheduled" tab to see who's pending. Use "Run now" button to trigger immediately.

## Test plan
- [ ] Run `017_api_logs.sql` migration in Supabase SQL Editor
- [ ] Click each stat card in admin Overview → panel opens with filtered user list
- [ ] Click a user in the panel → detail panel shows with 4 tabs
- [ ] Generate a resume → check Admin Logs tab for the log entry
- [ ] Admin → Notifications → Scheduled tab shows eligible users grouped by type
- [ ] Admin → Notifications → Sent history shows all past sends
- [ ] "Run now" button sends pending lifecycle emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)